### PR TITLE
Fix kfp-api extra service name

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -258,7 +258,9 @@ class Operator(CharmBase):
                         {
                             "name": "ml-pipeline",
                             "spec": {
-                                "selector": {"juju-app": self.model.app.name},
+                                "selector": {
+                                    "app.kubernetes.io/name": self.model.app.name
+                                },
                                 "ports": [
                                     {
                                         "name": "grpc",

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -47,7 +47,7 @@ def test_pipelines():
                 "microk8s",
                 "kubectl",
                 "get",
-                "services/kfp-api",
+                "services/ml-pipeline",
                 "-nkubeflow",
                 "-ojson",
             ]


### PR DESCRIPTION
kfp-api creates an extra Service object called `ml-pipeline` to be compatible with upstream Kubeflow. On Juju versions < 2.9, this Service object used a selector of `juju-app: kfp-api`. However, starting with Juju 2.9, that selector needs to be `app.kubernetes.io/name: kfp-api` instead.

Fixes #6