### PR TITLE
Update existing charms to 1.4, including multi-user features

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -31,7 +31,7 @@ options:
     description: If true, pipeline run steps can be cached instead of re-run
   runner-sa:
     type: string
-    default: "pipeline-runner"
+    default: "default-editor"
     description: |
       Default pipeline runner service account.
       Used if service account is left unspecified when creating a run

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/api-server:1.5.0-rc.0
+    upstream-source: gcr.io/ml-pipeline/api-server:1.7.0-rc.3
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -110,6 +110,7 @@ class Operator(CharmBase):
 
         config_json = {
             "DBConfig": {
+                "ConMaxLifeTimeSec": "120",
                 "DBName": mysql["database"],
                 "DriverName": "mysql",
                 "GroupConcatMaxLen": "4194304",
@@ -135,9 +136,16 @@ class Operator(CharmBase):
                 "auto-update-default-version"
             ],
             "CACHE_IMAGE": config["cache-image"],
+            "CACHE_NODE_RESTRICTIONS": "false",
             "CacheEnabled": str(config["cache-enabled"]).lower(),
+            # TODO: Default runner service account depends on multi-user (default-editor) vs single-user
+            #  (pipeline-runner).  Do we need a config for this exposed to user?
             "DefaultPipelineRunnerServiceAccount": config["runner-sa"],
             "InitConnectionTimeout": config["init-connection-timeout"],
+            "KUBEFLOW_USERID_HEADER": "kubeflow-userid",
+            "KUBEFLOW_USERID_PREFIX": "",
+            # TODO: Add multi-user/single-user toggle
+            "MULTIUSER": "true",
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": viz["service-name"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": viz["service-port"],
         }
@@ -151,6 +159,7 @@ class Operator(CharmBase):
                 "serviceAccount": {
                     "roles": [
                         {
+                            "global": True,
                             "rules": [
                                 {
                                     "apiGroups": [""],
@@ -279,6 +288,17 @@ class Operator(CharmBase):
                         }
                     ],
                     "serviceAccounts": [
+                        # TODO: Is this used in multi-user pipelines?  If not, we can disable if MU.
+                        #  I think this is the SA that enabled pipelines to run globally (SU) in the
+                        #  kubeflow namespace, but that MU instead uses the `default-editor` SA that
+                        #  is created by kubeflow-profiles in each individual namespace, thus this
+                        #  SA is not needed.  Searching through KFP codebase, we see this
+                        #  pipeline-runnner SA is not used directly in any of the SU or MU
+                        #  manifests but I think it is used by the kfp-api workload (the operator
+                        #  that actually runs kfp jobs)?
+                        # TODO: Confirm above by making a kfp run and checking the service account
+                        #  on the pod.  This would be called out by the default service account
+                        #  args passed to kfp-api above.
                         {
                             "name": "pipeline-runner",
                             "roles": [

--- a/charms/kfp-profile-controller/README.md
+++ b/charms/kfp-profile-controller/README.md
@@ -1,0 +1,13 @@
+## Kubeflow Pipelines API Operator
+
+### Overview
+This charm encompasses the Kubernetes Python operator for Kubeflow Pipelines
+Profile Controller (multi-user components of Kubeflow Pipelines) (see [CharmHub](https://charmhub.io/?q=kfp-profile-controller)).
+
+## Install
+
+To install Kubeflow Pipelines API, run:
+
+    juju deploy kfp-profile-controller
+
+For more information, see https://juju.is/docs

--- a/charms/kfp-profile-controller/charmcraft.yaml
+++ b/charms/kfp-profile-controller/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: "charm"
+bases:
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
+parts:
+  charm:
+    prime:
+      - ./files/upstream/sync.py

--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -1,0 +1,6 @@
+options:
+  http-port:
+    # TODO: This is ignored.  See note on CONTAINER_PORT in charm.py
+    type: string
+    default: '80'
+    description: kubeflow-pipelines-profile-controller deployment port

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -1,0 +1,391 @@
+# Copyright 2020-2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import os
+import base64
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    logger.info("Profile syncer starting")
+    settings = get_settings_from_env()
+    safe_settings = dict(settings)
+    for k in ["MINIO_ACCESS_KEY", "MINIO_SECRET_KEY"]:
+        if k in safe_settings:
+            safe_settings[k] = "REDACTED"
+    logger.info(f"Serrings = {settings}")
+    server = server_factory(**settings)
+    logger.info("Serving forever")
+    server.serve_forever()
+
+
+def get_settings_from_env(controller_port=None,
+                          visualization_server_image=None, frontend_image=None,
+                          visualization_server_tag=None, frontend_tag=None, disable_istio_sidecar=None,
+                          minio_access_key=None, minio_secret_key=None, kfp_default_pipeline_root=None):
+    """
+    Returns a dict of settings from environment variables relevant to the controller
+
+    Environment settings can be overridden by passing them here as arguments.
+
+    Settings are pulled from the all-caps version of the setting name.  The
+    following defaults are used if those environment variables are not set
+    to enable backwards compatibility with previous versions of this script:
+        visualization_server_image: gcr.io/ml-pipeline/visualization-server
+        visualization_server_tag: value of KFP_VERSION environment variable
+        frontend_image: gcr.io/ml-pipeline/frontend
+        frontend_tag: value of KFP_VERSION environment variable
+        disable_istio_sidecar: Required (no default)
+        minio_access_key: Required (no default)
+        minio_secret_key: Required (no default)
+    """
+    settings = dict()
+    settings["controller_port"] = \
+        controller_port or \
+        os.environ.get("CONTROLLER_PORT", "8080")
+
+    settings["visualization_server_image"] = \
+        visualization_server_image or \
+        os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+
+    settings["frontend_image"] = \
+        frontend_image or \
+        os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+
+    # Look for specific tags for each image first, falling back to
+    # previously used KFP_VERSION environment variable for backwards
+    # compatibility
+    settings["visualization_server_tag"] = \
+        visualization_server_tag or \
+        os.environ.get("VISUALIZATION_SERVER_TAG") or \
+        os.environ["KFP_VERSION"]
+
+    settings["frontend_tag"] = \
+        frontend_tag or \
+        os.environ.get("FRONTEND_TAG") or \
+        os.environ["KFP_VERSION"]
+
+    settings["disable_istio_sidecar"] = \
+        disable_istio_sidecar if disable_istio_sidecar is not None \
+            else os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+
+    settings["minio_access_key"] = \
+        minio_access_key or \
+        base64.b64encode(bytes(os.environ.get("MINIO_ACCESS_KEY"), 'utf-8')).decode('utf-8')
+
+    settings["minio_secret_key"] = \
+        minio_secret_key or \
+        base64.b64encode(bytes(os.environ.get("MINIO_SECRET_KEY"), 'utf-8')).decode('utf-8')
+
+    # KFP_DEFAULT_PIPELINE_ROOT is optional
+    settings["kfp_default_pipeline_root"] = \
+        kfp_default_pipeline_root or \
+        os.environ.get("KFP_DEFAULT_PIPELINE_ROOT")
+
+    return settings
+
+
+def server_factory(visualization_server_image,
+                   visualization_server_tag, frontend_image, frontend_tag,
+                   disable_istio_sidecar, minio_access_key,
+                   minio_secret_key, kfp_default_pipeline_root=None, 
+                   url="", controller_port=8080):
+    """
+    Returns an HTTPServer populated with Handler with customized settings
+    """
+    class Controller(BaseHTTPRequestHandler):
+        def sync(self, parent, children):
+            logger.info("Got new request")
+
+            # parent is a namespace
+            namespace = parent.get("metadata", {}).get("name")
+
+            pipeline_enabled = parent.get("metadata", {}).get(
+                "labels", {}).get("pipelines.kubeflow.org/enabled")
+
+            if pipeline_enabled != "true":
+                logger.info(f"Namespace not in scope, no action taken (metadata.labels.pipelines.kubeflow.org/enabled = {pipeline_enabled}, must be 'true')")
+                return {"status": {}, "children": []}
+
+            desired_configmap_count = 1
+            desired_resources = []
+            if kfp_default_pipeline_root:
+                desired_configmap_count = 2
+                desired_resources += [{
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "kfp-launcher",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "defaultPipelineRoot": kfp_default_pipeline_root,
+                    },
+                }]
+
+
+            # Compute status based on observed state.
+            desired_status = {
+                "kubeflow-pipelines-ready":
+                    len(children["Secret.v1"]) == 1 and
+                    len(children["ConfigMap.v1"]) == desired_configmap_count and
+                    len(children["Deployment.apps/v1"]) == 2 and
+                    len(children["Service.v1"]) == 2 and
+                    # TODO CANONICAL: This only works if istio is available.  Disabled for now
+                    # len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
+                    # len(children["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
+                    "True" or "False"
+            }
+
+            # Generate the desired child object(s).
+            desired_resources += [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "metadata-grpc-configmap",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "METADATA_GRPC_SERVICE_HOST":
+                            "metadata-grpc-service.kubeflow",
+                        "METADATA_GRPC_SERVICE_PORT": "8080",
+                    },
+                },
+                # Visualization server related manifests below
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-visualizationserver"
+                        },
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            },
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-visualizationserver"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "image": f"{visualization_server_image}:{visualization_server_tag}",
+                                    "imagePullPolicy":
+                                        "IfNotPresent",
+                                    "name":
+                                        "ml-pipeline-visualizationserver",
+                                    "ports": [{
+                                        "containerPort": 8888
+                                    }],
+                                    "resources": {
+                                        "requests": {
+                                            "cpu": "50m",
+                                            "memory": "200Mi"
+                                        },
+                                        "limits": {
+                                            "cpu": "500m",
+                                            "memory": "1Gi"
+                                        },
+                                    }
+                                }],
+                                "serviceAccountName":
+                                    "default-editor",
+                            },
+                        },
+                    },
+                },
+                # TODO CANONICAL: This only works if istio is available.  Disabled for now
+                # {
+                #     "apiVersion": "networking.istio.io/v1alpha3",
+                #     "kind": "DestinationRule",
+                #     "metadata": {
+                #         "name": "ml-pipeline-visualizationserver",
+                #         "namespace": namespace,
+                #     },
+                #     "spec": {
+                #         "host": "ml-pipeline-visualizationserver",
+                #         "trafficPolicy": {
+                #             "tls": {
+                #                 "mode": "ISTIO_MUTUAL"
+                #             }
+                #         }
+                #     }
+                # },
+                # {
+                #     "apiVersion": "security.istio.io/v1beta1",
+                #     "kind": "AuthorizationPolicy",
+                #     "metadata": {
+                #         "name": "ml-pipeline-visualizationserver",
+                #         "namespace": namespace,
+                #     },
+                #     "spec": {
+                #         "selector": {
+                #             "matchLabels": {
+                #                 "app": "ml-pipeline-visualizationserver"
+                #             }
+                #         },
+                #         "rules": [{
+                #             "from": [{
+                #                 "source": {
+                #                     "principals": ["cluster.local/ns/kubeflow/sa/ml-pipeline"]
+                #                 }
+                #             }]
+                #         }]
+                #     }
+                # },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name": "http",
+                            "port": 8888,
+                            "protocol": "TCP",
+                            "targetPort": 8888,
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-visualizationserver",
+                        },
+                    },
+                },
+                # Artifact fetcher related resources below.
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        },
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-ui-artifact"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-ui-artifact"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "name":
+                                        "ml-pipeline-ui-artifact",
+                                    "image": f"{frontend_image}:{frontend_tag}",
+                                    "imagePullPolicy":
+                                        "IfNotPresent",
+                                    "ports": [{
+                                        "containerPort": 3000
+                                    }],
+                                    "resources": {
+                                        "requests": {
+                                            "cpu": "10m",
+                                            "memory": "70Mi"
+                                        },
+                                        "limits": {
+                                            "cpu": "100m",
+                                            "memory": "500Mi"
+                                        },
+                                    }
+                                }],
+                                "serviceAccountName":
+                                    "default-editor"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name":
+                                "http",  # name is required to let istio understand request protocol
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 3000
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    }
+                },
+            ]
+            print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
+            print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))
+            # Moved after the print argument because this is sensitive data.
+            desired_resources.append({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": "mlpipeline-minio-artifact",
+                    "namespace": namespace,
+                },
+                "data": {
+                    "accesskey": minio_access_key,
+                    "secretkey": minio_secret_key,
+                },
+            })
+
+            return {"status": desired_status, "children": desired_resources}
+
+        def do_POST(self):
+            # Serve the sync() function as a JSON webhook.
+            observed = json.loads(
+                self.rfile.read(int(self.headers.get("content-length"))))
+            desired = self.sync(observed["parent"], observed["children"])
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+
+    return HTTPServer((url, int(controller_port)), Controller)
+
+
+if __name__ == "__main__":
+    main()

--- a/charms/kfp-profile-controller/icon.svg
+++ b/charms/kfp-profile-controller/icon.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg30"
+   sodipodi:docname="kubeflow.svg"
+   width="200"
+   height="200"
+   inkscape:version="0.92.4 (33fec40, 2019-01-16)">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1712"
+     inkscape:window-height="908"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="2.6297579"
+     inkscape:cx="98.948417"
+     inkscape:cy="91.336583"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g26" />
+  <g
+     data-name="Layer 2"
+     id="g28"
+     transform="translate(-44.46,17.020004)">
+    <g
+       data-name="Layer 1"
+       id="g26">
+      <path
+         d="m 103.455,53.639996 4.1,102.100004 73.75,-94.120004 a 6.79,6.79 0 0 1 9.6,-1.11 l 46,36.92 -15,-65.61 z"
+         id="path10"
+         inkscape:connector-curvature="0"
+         style="fill:#4279f4" />
+      <path
+         d="m 110.105,174.47 h 65.42 l -40.17,-32.23 z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#0028aa" />
+      <path
+         d="m 187.735,75.409996 -44,56.140004 46.88,37.61 44.47,-55.76 z"
+         id="path14"
+         inkscape:connector-curvature="0"
+         style="fill:#014bd1" />
+      <path
+         d="m 91.115,43.789996 0.01,-0.01 38.69,-48.52 -62.39,30.05 -15.41,67.51 z"
+         id="path16"
+         inkscape:connector-curvature="0"
+         style="fill:#bedcff" />
+      <path
+         d="m 52.875,113.54 41.44,51.96 -3.95,-98.980004 z"
+         id="path18"
+         inkscape:connector-curvature="0"
+         style="fill:#6ca1ff" />
+      <path
+         d="m 209.865,20.219996 -59.66,-28.73 -37.13,46.56 z"
+         id="path20"
+         inkscape:connector-curvature="0"
+         style="fill:#a1c3ff" />
+    </g>
+  </g>
+</svg>

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -1,0 +1,24 @@
+name: kfp-profile-controller
+display-name: Kubeflow Pipelines Profile Controller
+summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
+description: |
+  Machine learning (ML) toolkit that is dedicated to making deployments
+  of ML workflows on Kubernetes simple, portable, and scalable.
+maintainers:
+  - "Dominik Fleischmann <dominik.fleischmann@canonical.com>"
+  - "Kenneth Koski <kenneth.koski@canonical.com>"
+  - "Andrew Scribner <andrew.scribner@canonical.com>"
+tags: [ai, big-data, kubeflow, machine-learning, tensorflow]
+series: [kubernetes]
+resources:
+  oci-image:
+    type: oci-image
+    description: Backing OCI image
+    auto-fetch: true
+    upstream-source: python:3.7
+requires:
+  object-storage:
+    interface: object-storage
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    versions: [v1]
+min-juju-version: 2.8.6

--- a/charms/kfp-profile-controller/requirements.txt
+++ b/charms/kfp-profile-controller/requirements.txt
@@ -1,0 +1,3 @@
+ops==1.1.0
+oci-image==1.0.0
+serialized-data-interface<0.4   

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+import logging
+from pathlib import Path
+
+from oci_image import OCIImageResource, OCIImageResourceError
+from ops.charm import CharmBase
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from serialized_data_interface import (
+    NoCompatibleVersions,
+    NoVersionsListed,
+    get_interfaces,
+)
+
+
+# This must be hard-coded to port 80 because the metacontroller webhook that talks to this port only
+# communicates over port 80.  Upstream uses the service to map 80->8080 but we cannot via podspec.
+CONTROLLER_PORT = 80
+
+# TODO: Istio destinationrule/auth manually disabled in sync.py.  Need a better solution for this.
+# TODO: If we start this without a relation to the object-storage, it sits in Active status.  Does it ever have warning about missing relation?
+
+
+class Operator(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.log = logging.getLogger()
+
+        if not self.model.unit.is_leader():
+            self.log.info("Not a leader, skipping set_pod_spec")
+            self.model.unit.status = ActiveStatus()
+            return
+
+        self.image = OCIImageResource(self, "oci-image")
+
+        try:
+            self.interfaces = get_interfaces(self)
+        except NoVersionsListed as err:
+            self.model.unit.status = WaitingStatus(str(err))
+            return
+        except NoCompatibleVersions as err:
+            self.model.unit.status = BlockedStatus(str(err))
+            return
+        else:
+            self.model.unit.status = ActiveStatus()
+
+        change_events = [
+            self.on.install,
+            self.on.upgrade_charm,
+            self.on.config_changed,
+        ]
+
+        for event in change_events:
+            self.framework.observe(event, self.set_pod_spec)
+
+        for relation in self.interfaces.keys():
+            self.framework.observe(
+                self.on[relation].relation_changed,
+                self.set_pod_spec,
+            )
+            # self.framework.observe(
+                # self.on[relation].relation_changed,
+                # self.send_info,
+            # )
+
+    # def send_info(self, event):
+    #     if self.interfaces["kfp-api"]:
+    #         self.interfaces["kfp-api"].send_data(
+    #             {
+    #                 "service-name": self.model.app.name,
+    #                 "service-port": self.model.config["http-port"],
+    #             }
+    #         )
+
+    def set_pod_spec(self, event):
+        try:
+            image_details = self.image.fetch()
+        except OCIImageResourceError as e:
+            self.model.unit.status = e.status
+            self.log.info(e)
+            return
+
+        config = self.model.config
+
+        # TODO: this didn't seem to work.  if deployed before object storage is up, still goes
+        #  to active state
+        if not ((os := self.interfaces["object-storage"]) and os.get_data()):
+            self.model.unit.status = WaitingStatus(
+                "Waiting for object-storage relation data"
+            )
+            return
+
+        logging.info("Found all required relations - proceeding to setting pod spec")
+        self.model.unit.status = MaintenanceStatus("Setting pod spec")
+        os = list(os.get_data().values())[0]
+
+        deployment_env = {
+            "MINIO_ACCESS_KEY": os["access-key"],
+            "MINIO_SECRET_KEY": os["secret-key"],
+            # TODO: This sets the version of the images used in each namespace, coming from the
+            #  configMap pipeline-install-config's appVersion entry.  Should this be a config option?  It'll be updated whenever we update the charm
+            "KFP_VERSION": "1.7.0-rc.3",
+            "KFP_DEFAULT_PIPELINE_ROOT": "",
+            "DISABLE_ISTIO_SIDECAR": "false",
+            "CONTROLLER_PORT": CONTROLLER_PORT,
+        }
+
+        self.model.pod.set_spec(
+            {
+                "version": 3,
+                "containers": [
+                    {
+                        # TODO: annotations: sidecar.istio.io/inject: "false"
+                        # TODO: labels?
+                        "name": "kubeflow-pipelines-profile-controller",
+                        "command": ["python"],
+                        "args": ["/hooks/sync.py"],
+                        "imageDetails": image_details,
+                        "ports": [
+                            {
+                                "name": "http",
+                                "containerPort": CONTROLLER_PORT,
+                                "protocol": "TCP",
+                            },
+                        ],
+                        "envConfig": deployment_env,
+                        "volumeConfig": [
+                            {
+                                "name": "kubeflow-pipelines-profile-controller-code",
+                                "mountPath": "/hooks",
+                                "configMap": {
+                                    "name": "kubeflow-pipelines-profile-controller-code",
+                                    "files": [
+                                        {
+                                            "key": "sync.py",
+                                            "path": "sync.py",
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            k8s_resources={
+                "kubernetesResources": {
+                    "customResources": {
+                        "compositecontrollers.metacontroller.k8s.io": [
+                            {
+                                "apiVersion": "metacontroller.k8s.io/v1alpha1",
+                                "kind": "CompositeController",
+                                "metadata": {
+                                    "name": "kubeflow-pipelines-profile-controller",
+                                    # "labels": {}, # TODO: Include labels?  think they might be defined at metadata indentation
+                                },
+                                "spec": {
+                                    "childResources": [
+                                        {
+                                            "apiVersion": "v1",
+                                            "resource": "secrets",
+                                            "updateStrategy": {"method": "OnDelete"},
+                                        },
+                                        {
+                                            "apiVersion": "v1",
+                                            "resource": "configmaps",
+                                            "updateStrategy": {"method": "OnDelete"},
+                                        },
+                                        {
+                                            "apiVersion": "apps/v1",
+                                            "resource": "deployments",
+                                            "updateStrategy": {"method": "InPlace"},
+                                        },
+                                        {
+                                            "apiVersion": "v1",
+                                            "resource": "services",
+                                            "updateStrategy": {"method": "InPlace"},
+                                        },
+                                        # TODO: This only works if istio is available.  Disabled for now
+                                        # {
+                                        #     "apiVersion": "networking.istio.io/v1alpha3",
+                                        #     "resource": "destinationrules",
+                                        #     "updateStrategy": {"method": "InPlace"},
+                                        # },
+                                        # {
+                                        #     "apiVersion": "security.istio.io/v1beta1",
+                                        #     "resource": "authorizationpolicies",
+                                        #     "updateStrategy": {"method": "InPlace"},
+                                        # },
+                                    ],
+                                    "generateSelector": True,
+                                    "hooks": {
+                                        "sync": {
+                                            "webhook": {
+                                                # TODO: This name must match the service Juju creates for our above workload, which matches the name given to the kfp-profile-controller app at deployment(?)
+                                                "url": "http://kfp-profile-controller/sync"
+                                            }
+                                        }
+                                    },
+                                    "parentResource": {
+                                        "apiVersion": "v1",
+                                        "resource": "namespaces",
+                                    },
+                                    "resyncPeriodSeconds": 10,
+                                },
+                            }
+                        ]
+                    },
+                },
+                "configMaps": {
+                    "kubeflow-pipelines-profile-controller-code": {
+                        "sync.py": Path("files/upstream/sync.py").read_text(),
+                    },
+                },
+            },
+        )
+        self.model.unit.status = ActiveStatus()
+
+# TODO: Restore the readiness probes?
+
+
+if __name__ == "__main__":
+    main(Operator)

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -100,7 +100,8 @@ class Operator(CharmBase):
             "MINIO_ACCESS_KEY": os["access-key"],
             "MINIO_SECRET_KEY": os["secret-key"],
             # TODO: This sets the version of the images used in each namespace, coming from the
-            #  configMap pipeline-install-config's appVersion entry.  Should this be a config option?  It'll be updated whenever we update the charm
+            #  configMap pipeline-install-config's appVersion entry.  Should this be a config option?
+            #  It'll be updated whenever we update the charm.  Probably should just read it from tag
             "KFP_VERSION": "1.7.0-rc.3",
             "KFP_DEFAULT_PIPELINE_ROOT": "",
             "DISABLE_ISTIO_SIDECAR": "false",

--- a/charms/kfp-profile-controller/test-integration-requirements.txt
+++ b/charms/kfp-profile-controller/test-integration-requirements.txt
@@ -1,0 +1,1 @@
+pytest-operator > 0.8.2

--- a/charms/kfp-profile-controller/test-requirements.txt
+++ b/charms/kfp-profile-controller/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pyyaml

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,0 +1,49 @@
+import logging
+from pathlib import Path
+
+import yaml
+
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "kfp-profile-controller"
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
+
+
+async def test_build_and_deploy(ops_test: OpsTest):
+    built_charm_path = await ops_test.build_charm("./")
+    logger.info(f"Built charm {built_charm_path}")
+
+    image_path = METADATA["resources"]["oci-image"]["upstream-source"]
+    resources = {"oci-image": image_path}
+
+    await ops_test.model.deploy(
+        entity_url=built_charm_path,
+        application_name=APP_NAME,
+        resources=resources,
+    )
+
+    # Deploy required relations
+    await ops_test.model.deploy(entity_url="minio", config=MINIO_CONFIG)
+    await ops_test.model.add_relation(
+        f"{APP_NAME}:object-storage",
+        "minio:object-storage",
+    )
+
+    # TODO: Need a better test for checking everything is ok
+    # Maybe: await ops_test.model.wait_for_idle(raise_on_error=False, raise_on_blocked=True) or similar?
+    await ops_test.model.wait_for_idle(timeout=60 * 10)
+
+
+# TODO: Real testing requires:
+#  * kubeflow-profile controller, or something that will make namespaces/service accounts in a
+#    similar fashion (some resources deployed to each namespace by kfp-profile-controller use the
+#    `default-editor` service account, which is created by the main kubeflow-profile controller)
+#  * This charm deploying successfully is not a full test of function.  We need to create a new
+#    tracked namespace (namespace that has label pipelines.kubeflow.org/enabled=true) and ensure all
+#    expected resources are deployed and come up successfully (eg: if service account is not found,
+#    deployments will exist but pods will never be "ready")
+

--- a/charms/kfp-profile-controller/tests/readme.md
+++ b/charms/kfp-profile-controller/tests/readme.md
@@ -1,0 +1,26 @@
+# Manual Testing
+
+To manually test this charm, you can:
+
+* deploy metacontroller charm
+* deploy kubeflow-profiles charm (the regular one)
+* deploy minio
+* deploy kfp-profile-controller & relate to minio
+
+Juju should now make a kfp-profile-controller pod/service, a metacontroller `CompositeController` object.  Once they're up, any namespace associated with a Profile (from the kubeflow-profile charm) should have a few easily distinguished pods/services etc added to them (named things like 'kfp-visualization').
+
+For a deeper look behind the scenes as it works:
+
+* `kubectl logs` on metacontroller's pod (the real pod, not the juju operator's pod) and it gives a nice log of the namespaces it is checking
+* `kubectl logs` on the kfp-profile-controller that deploys the sync.py webserver. Whenever it gets hit with a valid request it'll print the json that it returns
+
+You can also directly test the actual controller in the kfp-profile-controller charm by doing the following from an existing pod on the kubernetes cluster:
+```bash
+curl http://kubeflow-pipelines-profile-controller:CONTROLLER_PORT/sync -d '{"parent":{"metadata":{"name":"someName","labels":{"pipelines.kubeflow.org/enabled":"true"}}},"children":{"Secret.v1":[],"ConfigMap.v1":[],"Deployment.apps/v1":[],"Service.v1":[],"DestinationRule.networking.istio.io/v1alpha3":[],"AuthorizationPolicy.security.istio.io/v1beta1":[]}}'
+```
+
+This mimics what Metacontroller will send the kubeflow-pipelines-profile-controller, ad JSON blob of:
+* parent: JSON of the namespace that triggered this reconciliation loop
+* children: JSON of the children of this reconciliation loop (eg: the children objects it is ensuring ecist).  In this case, we send empty lists which will require reconciliation.
+
+Returned will be a JSON blob for the desired state of the children. 

--- a/charms/kfp-profile-controller/tox.ini
+++ b/charms/kfp-profile-controller/tox.ini
@@ -1,0 +1,32 @@
+[flake8]
+max-line-length = 100
+
+[tox]
+skipsdist = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}/src:{toxinidir}/lib
+deps =
+    -rtest-requirements.txt
+    -rrequirements.txt
+
+; TODO
+;[testenv:unit]
+;commands =
+;    pytest -v {toxinidir}/tests/unit
+
+[testenv:integration]
+deps =
+    {[testenv]deps}
+    -r test-integration-requirements.txt
+commands =
+    pytest -v --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
+
+[testenv:lint]
+deps =
+    black==20.8b1
+    flake8
+commands =
+    flake8 {toxinidir}/src {toxinidir}/tests
+    black --check {toxinidir}/src {toxinidir}/tests

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/frontend:1.5.0-rc.0
+    upstream-source: gcr.io/ml-pipeline/frontend:1.7.0-rc.3
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -108,15 +108,22 @@ class Operator(CharmBase):
             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
             "ARGO_ARCHIVE_LOGS": "false",
             "ARGO_ARCHIVE_PREFIX": "logs",
+            # TODO: This should come from relation to kfp-profile-controller.  It is the name/port
+            #  of the user-specific artifact accessor
+            "ARTIFACTS_SERVICE_PROXY_NAME": "ml-pipeline-ui-artifact",
+            "ARTIFACTS_SERVICE_PROXY_PORT": "80",
+            "ARTIFACTS_SERVICE_PROXY_ENABLED": "true",
             "AWS_ACCESS_KEY_ID": "",
             "AWS_SECRET_ACCESS_KEY": "",
             "DISABLE_GKE_METADATA": "false",
-            "ENABLE_AUTHZ": "false",
+            "ENABLE_AUTHZ": "true",   # TODO: Working?  Does it work if this is off?
             "DEPLOYMENT": "KUBEFLOW",
             "HIDE_SIDENAV": str(config["hide-sidenav"]).lower(),
             "HTTP_AUTHORIZATION_DEFAULT_VALUE": "",
             "HTTP_AUTHORIZATION_KEY": "",
             "HTTP_BASE_URL": "",
+            "KUBEFLOW_USERID_HEADER": "kubeflow-userid",
+            "KUBEFLOW_USERID_PREFIX": "",
             "METADATA_ENVOY_SERVICE_SERVICE_HOST": "localhost",
             "METADATA_ENVOY_SERVICE_SERVICE_PORT": "9090",
             "MINIO_ACCESS_KEY": os["access-key"],
@@ -128,6 +135,8 @@ class Operator(CharmBase):
             "ML_PIPELINE_SERVICE_HOST": api["service-name"],
             "ML_PIPELINE_SERVICE_PORT": api["service-port"],
             "STREAM_LOGS_FROM_SERVER_API": "false",
+            # TODO: Think there's a file here we should copy in.  Workload's logs show an error on
+            #  start for this
             "VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH": "/etc/config/viewer-pod-template.json",
             "VIEWER_TENSORBOARD_TF_IMAGE_NAME": "tensorflow/tensorflow",
         }
@@ -143,6 +152,7 @@ class Operator(CharmBase):
                 "serviceAccount": {
                     "roles": [
                         {
+                            "global": True,
                             "rules": [
                                 {
                                     "apiGroups": [""],


### PR DESCRIPTION
This PR implements multiuser support for kubeflow pipelines.  Included are:

* setting kfp-api to multiuser and updating kf release 1.4
* setting kfp-ui to multiuser and updating to kf release 1.4
* adding charm for the kubeflow-pipelines-profile-controller