### PR TITLE
Add prometheus integration

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -1,4 +1,8 @@
 options:
+  k8s-service-name:
+    default: "ml-pipeline"
+    description: |
+      Name of the Kubernetes service where kfp-api will expose itself
   grpc-port:
     type: string
     default: '8887'
@@ -41,3 +45,8 @@ options:
     description: |
       Connection timeout used when initializing clients for related services.
       The format used can be anything accepted by `time.ParseDuration`.
+  prometheus-path:
+    type: string
+    default: "/metrics"
+    description: |
+      Prometheus path used for the scrape job. 

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -25,3 +25,5 @@ provides:
     interface: k8s-service
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
     versions: [v1]
+  monitoring:
+    interface: prometheus_scrape

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -1,3 +1,3 @@
-ops==1.2.0
+ops==1.3.0
 oci-image==1.0.0
 serialized-data-interface<0.4   

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.3.0
 oci-image==1.0.0
-serialized-data-interface<0.4   
+serialized-data-interface<0.4

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -49,12 +49,6 @@ class KfpApiOperator(CharmBase):
         ]
         for event in change_events:
             self.framework.observe(event, self._main)
-        # Pass the service URL as the target
-        target = "%s.%s.svc:%s" % (
-            self.config["k8s-service-name"],
-            self.model.name,
-            self.config["http-port"],
-        )
         self.prometheus_provider = MetricsEndpointProvider(
             charm=self,
             relation_name="monitoring",
@@ -63,7 +57,7 @@ class KfpApiOperator(CharmBase):
                     "job_name": "ml_pipeline",
                     "scrape_interval": "30s",
                     "metrics_path": self.config["prometheus-path"],
-                    "static_configs": [{"targets": [target]}],
+                    "static_configs": [{"targets": ["*:{}".format(self.config["http-port"])]}],
                 }
             ],
         )

--- a/charms/kfp-api/src/prometheus_alert_rules/__init__.py
+++ b/charms/kfp-api/src/prometheus_alert_rules/__init__.py
@@ -1,0 +1,4 @@
+# prometheus_alert_rules folder is only added to .charm file
+# if there is any relevant content.
+# Adding this file only to ensure the folder is added to the
+# charm and MetricsEndpointProvider does complain.

--- a/charms/kfp-api/src/prometheus_alert_rules/__init__.py
+++ b/charms/kfp-api/src/prometheus_alert_rules/__init__.py
@@ -1,4 +1,0 @@
-# prometheus_alert_rules folder is only added to .charm file
-# if there is any relevant content.
-# Adding this file only to ensure the folder is added to the
-# charm and MetricsEndpointProvider does complain.

--- a/charms/kfp-api/src/prometheus_alert_rules/tempfile
+++ b/charms/kfp-api/src/prometheus_alert_rules/tempfile
@@ -1,0 +1,5 @@
+"""prometheus_alert_rules folder is only added to .charm file 
+if there is any relevant content.
+Adding this file only to ensure the folder is added to the
+charm and MetricsEndpointProvider does not complain.
+"""

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -289,7 +290,7 @@ def test_install_with_all_inputs(harness, oci_resource_data):
     model_name = "test_model"
     service_port = "8888"
     harness.set_model_name(model_name)
-    harness.update_config({"service-port": service_port})
+    harness.update_config({"http-port": service_port})
 
     # Set up required relations
     # Future: convert these to fixtures and share with the tests above
@@ -365,3 +366,30 @@ def oci_resource_data():
             "password": "",
         },
     }
+
+
+def test_prometheus_data_set(harness, mocker):
+    harness.set_leader(True)
+    harness.set_model_name("kubeflow")
+    harness.begin()
+
+    mock_net_get = mocker.patch("ops.testing._TestingModelBackend.network_get")
+    mocker.patch("ops.testing._TestingPebbleClient.list_files")
+
+    bind_address = "1.1.1.1"
+    fake_network = {
+        "bind-addresses": [
+            {
+                "interface-name": "eth0",
+                "addresses": [{"hostname": "cassandra-tester-0", "value": bind_address}],
+            }
+        ]
+    }
+    mock_net_get.return_value = fake_network
+    rel_id = harness.add_relation("monitoring", "otherapp")
+    harness.add_relation_unit(rel_id, "otherapp/0")
+    harness.update_relation_data(rel_id, "otherapp", {})
+
+    assert json.loads(harness.get_relation_data(rel_id, harness.model.app.name)["scrape_jobs"])[0][
+        "static_configs"
+    ][0]["targets"] == ["ml-pipeline.kubeflow.svc:8888"]

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -392,4 +392,4 @@ def test_prometheus_data_set(harness, mocker):
 
     assert json.loads(harness.get_relation_data(rel_id, harness.model.app.name)["scrape_jobs"])[0][
         "static_configs"
-    ][0]["targets"] == ["ml-pipeline.kubeflow.svc:8888"]
+    ][0]["targets"] == ["*:8888"]

--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -55,6 +55,7 @@ description = Run unit tests
 deps =
     pytest
     pyyaml
+    pytest-mock
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Integrate with prometheus-k8s using prometheus_scrape interface
to submit a job. Prometheus should scrape the Pod IP on port
8888 by default to recover the metrics.

Moved to ops 1.3.0 to support prometheus_scrape.py interface.