### PR TITLE
add a PodDefault for pipelines access to all Profiles

### DIFF
--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -379,6 +379,56 @@ def server_factory(visualization_server_image,
                         }
                     }
                 },
+                # Added from https://github.com/kubeflow/pipelines/pull/6629 to fix
+                # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
+                # upstream and if they go with something different we should consider syncing with
+                # upstream.
+                # Adds "Allow access to Kubeflow Pipelines" button in Notebook spawner UI
+                {
+                    "apiVersion": "kubeflow.org/v1alpha1",
+                    "kind": "PodDefault",
+                    "metadata": {
+                        "name": "access-ml-pipeline",
+                        "namespace": namespace
+                    },
+                    "spec": {
+                        "desc": "Allow access to Kubeflow Pipelines",
+                        "selector": {
+                            "matchLabels": {
+                                "access-ml-pipeline": "true"
+                            }
+                        },
+                        "volumes": [
+                            {
+                                "name": "volume-kf-pipeline-token",
+                                "projected": {
+                                    "sources": [
+                                        {
+                                            "serviceAccountToken": {
+                                                "path": "token",
+                                                "expirationSeconds": 7200,
+                                                "audience": "pipelines.kubeflow.org"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/secrets/kubeflow/pipelines",
+                                "name": "volume-kf-pipeline-token",
+                                "readOnly": True
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "KF_PIPELINES_SA_TOKEN_PATH",
+                                "value": "/var/run/secrets/kubeflow/pipelines/token"
+                            }
+                        ]
+                    }
+                },
                 {
                     "apiVersion": "v1",
                     "kind": "Service",

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -153,6 +153,18 @@ class KfpProfileControllerOperator(CharmBase):
                                             "resource": "services",
                                             "updateStrategy": {"method": "InPlace"},
                                         },
+                                        # Added from
+                                        # https://github.com/kubeflow/pipelines/pull/6629/files to
+                                        # fix
+                                        # https://github.com/canonical/bundle-kubeflow/issues/423.
+                                        # This was not yet in upstream and if they go with
+                                        # something different we should consider syncing with
+                                        # upstream
+                                        {
+                                            "apiVersion": "kubeflow.org/v1alpha1",
+                                            "resource": "poddefaults",
+                                            "updateStrategy": {"method": "InPlace"},
+                                        },
                                         # TODO: This only works if istio is available.  Disabled
                                         #  for now and add back when istio checked as dependency
                                         # {


### PR DESCRIPTION
This change partly addresses https://github.com/canonical/bundle-kubeflow/issues/423

This updates the kfp metacontroller managed by the kfp-profile-controller to add a new PodDefault to all user namespaces (Profiles).  This PodDefault, when selected, lets Notebooks access the pipelines client without explicitly authenticating.

The change here adds the PodDefault, but it does not automatically enable the kfp access.  PodDefaults in a user's namespace are noticed by the notebook controller (charm: jupyter-ui) and shown to a user in the Notebook spawner UI under "Configurations".  To enable this kfp integration, users must enable this new configuration "Allow access to Kubeflow Pipelines".

This PodDefault can also be used by other workloads that might need access, such as a step of a pipeline.  See the [admission-webhook readme](https://github.com/kubeflow/kubeflow/blob/master/components/admission-webhook/README.md) for more info.

![image](https://user-images.githubusercontent.com/48125859/151572851-5ec4fcc0-57ce-4b4a-b8ab-11fd43b2ef96.png)