### PR TITLE
fix: ensure minio creds in namespace are updated on change

### DIFF
--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -136,7 +136,8 @@ class KfpProfileControllerOperator(CharmBase):
                                         {
                                             "apiVersion": "v1",
                                             "resource": "secrets",
-                                            "updateStrategy": {"method": "OnDelete"},
+                                            # TODO: Push this change upstream
+                                            "updateStrategy": {"method": "InPlace"},
                                         },
                                         {
                                             "apiVersion": "v1",

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -48,3 +48,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
 #    tracked namespace (namespace that has label pipelines.kubeflow.org/enabled=true) and ensure
 #    all expected resources are deployed and come up successfully (eg: if service account is not
 #    found, deployments will exist but pods will never be "ready")
+#  * check whether secrets and other things get updated based on the config sent to sync.py/kfppc
+#  * could create namespaces with the right pipelines label to trigger the sync, but also need to
+#    create a dummy poddefaults CRD too


### PR DESCRIPTION
Fixes an issue where the metacontroller defined by the kfp-profile-controller does not update the object storage credentials (stored in the `mlpipeline-minio-artifact` secret in each user's namespace), even though the kfp-profile-controller itself is informed of the new creds.  This was caused by using the `OnDelete` update mode in the metacontroller, which will only update the object if it is fully deleted (and not if it has just changed).  This is now set to `InPlace`, which always updates the object if the desired state differs from the current state (similar to if you did a `kubectl apply`).

Closes #56