### PR TITLE
Unpinned pytest-operator version

### DIFF
--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -67,6 +67,6 @@ description = Run integration tests
 deps =
     {[testenv:unit]deps}
     juju
-    pytest-operator<0.17.0
+    pytest-operator
 commands =
     pytest -v -s {posargs} {[vars]tst_path}/integration

--- a/charms/kfp-profile-controller/tox.ini
+++ b/charms/kfp-profile-controller/tox.ini
@@ -68,7 +68,7 @@ description = Run integration tests
 deps =
     {[testenv:unit]deps}
     juju
-    pytest-operator<0.17.0
+    pytest-operator
     lightkube<0.11
     tenacity<8.1
 commands =


### PR DESCRIPTION
Unpinned `pytest-operator<0.17.0` due to recent `pytest-operator` update which fixed the teardown issues.