### PR TITLE
update config options for kfp-profile-controller per kfp v2.0.0-alpha.3

### DIFF
--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -10,6 +10,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     upstream-source: python:3.7
+  # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -194,7 +194,7 @@ class KfpProfileControllerOperator(CharmBase):
                                         "apiVersion": "v1",
                                         "resource": "namespaces",
                                     },
-                                    "resyncPeriodSeconds": 10,
+                                    "resyncPeriodSeconds": 3600,
                                 },
                             }
                         ]

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -31,7 +31,7 @@ CONTROLLER_PORT = 80
 # TODO: This sets the version of the images deployed to each namespace (value comes from the
 #  upstream configMap pipeline-install-config's appVersion entry).  Normal pattern would
 #  set this in metadata but this is different here.  Should this be exposed differently?
-KFP_IMAGES_VERSION = "1.7.0-rc.3"
+KFP_IMAGES_VERSION = "2.0.0-alpha.3"
 
 # Note: Istio destinationrule/auth have been manually disabled in sync.py.  Need a better
 # solution for this in future


### PR DESCRIPTION
Note this is merging into a feature branch, not main, as it should not be released without the rest of kfp v2.0.0

This updates the profile controller to kfp v2.0.0-alpha.3.  No workload needs to be updated as this component has no binary workload