### PR TITLE
Pin flake8 to 4.0.1 and upgrade charming-actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
+        uses: canonical/charming-actions/check-libraries@2.0.0-rc
         with:
           credentials: "${{ secrets.charmcraft-credentials }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,10 +29,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.3
+        uses: canonical/charming-actions/channel@2.0.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.3
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
           credentials: ${{ secrets.charmcraft-credentials }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@1.0.3
+        uses: canonical/charming-actions/release-charm@2.0.0-rc
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-persistence/tox.ini
+++ b/charms/kfp-persistence/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-profile-controller/tox.ini
+++ b/charms/kfp-profile-controller/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-schedwf/tox.ini
+++ b/charms/kfp-schedwf/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-ui/tox.ini
+++ b/charms/kfp-ui/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-viewer/tox.ini
+++ b/charms/kfp-viewer/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/kfp-viz/tox.ini
+++ b/charms/kfp-viz/tox.ini
@@ -33,7 +33,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Some of the test dependencies that rely on flake8 are failing with the latest version, therefore we will pin to 4.0.1 for now.

Additionally some things have changed in charmcraft 2.0.0 breaking the previous charming-actions version, therfore we also upgrade it to 2.0.0-rc.