### PR TITLE
feat: dynamic sidebar content

### DIFF
--- a/charms/kfp-ui/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
+++ b/charms/kfp-ui/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
@@ -1,0 +1,129 @@
+"""# KubeflowDashboardSidebar Library
+This library is designated to ease the process of adding the componentes 
+to the UI sidebar of Kubeflow dashboard. The sidbar is dynamic and allows 
+to add and remove items based on the configmap content.
+
+In order to add an item to the library `sidebar` relation needs to be established
+between the application which is going to be added and the kubeflow dashboard application.
+At the joining event the joning application needs to send a json containing the sidebar element
+details. Charm using this library is expected to provide these details on initialization.
+These details are send through relation data.
+
+These are the required fields:
+- **type**: type of the sidebar element (only `item` option is allowed)
+- **link**: relative path to the place of redirection.
+- **text**: text of the displayed sidebar element
+- **icon**: icon of the sidebar element
+
+Bellow is the example (for tensorboards application) of json body. Remember list of configuration
+is expected so one or many sidebars can be added at the same time:
+```
+{
+    "position": 3,
+    "type": "item",
+    "link": "/tensorboards/",
+    "text": "Tensorboards",
+    "icon": "assessment",
+}
+```
+
+In oder to remove the item from the sidebar `sidebar` relation needs to be removed.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar
+```
+
+Then, to initialise the library:
+
+```python
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar import (
+    KubeflowDashboardSidebar,
+)
+# ...
+
+SIDEBAR_LINK = [
+    {
+        "position": 4,
+        "type": "item",
+        "link": "/tensorboards/",
+        "text": "Tensorboards",
+        "icon": "assessment",
+    }
+] # list of items must be provided
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.kubeflow_dashboard_sidebar = KubeflowDashboardSidebar(self, SIDEBAR_LINK)
+    # ...
+```
+"""
+
+import json
+import logging
+
+from typing import Dict
+from ops.charm import CharmBase, RelationJoinedEvent, RelationDepartedEvent
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a5795a88ee31458f9bc3ae026a04b89f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class KubeflowDashboardSidebar(Object):
+    def __init__(
+        self,
+        charm: CharmBase,
+        sidebar_link: Dict,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            sidebar_link: dictionary specifying the elemnt of the sidebar to be added.
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+        self.sidebar_link = sidebar_link
+        self.framework.observe(
+            self.charm.on.sidebar_relation_joined,
+            self._on_sidebar_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
+
+    def _on_sidebar_relation_joined(self, event: RelationJoinedEvent):
+        """Send the confing  on relation joined
+
+        Args:
+            event: relation joined object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps(self.sidebar_link)})
+
+    def _on_sidebar_relation_departed(self, event: RelationDepartedEvent):
+        """Remove the confing  on relation departed
+
+        Args:
+            event: relation departed object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps([])})

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -28,3 +28,6 @@ provides:
     interface: k8s-service
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
     versions: [v1]
+  sidebar:
+    interface: sidebar
+    optional: true

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -47,6 +47,10 @@ class KfpUiOperator(CharmBase):
         self.framework.observe(self.on["kfp-ui"].relation_changed, self._main)
         self.framework.observe(self.on.leader_elected, self._main)
         self.framework.observe(self.on.sidebar_relation_joined, self._on_sidebar_relation_joined)
+        self.framework.observe(
+            self.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
 
     def _main(self, event):
         try:
@@ -330,6 +334,7 @@ class KfpUiOperator(CharmBase):
                     [
                         {
                             "app": self.app.name,
+                            "position": 1,
                             "type": "item",
                             "text": "Experiments (KFP)",
                             "link": "/pipeline/#/experiments",
@@ -337,6 +342,7 @@ class KfpUiOperator(CharmBase):
                         },
                         {
                             "app": self.app.name,
+                            "position": 1,
                             "type": "item",
                             "link": "/pipeline/#/pipelines",
                             "text": "Pipelines",
@@ -344,6 +350,7 @@ class KfpUiOperator(CharmBase):
                         },
                         {
                             "app": self.app.name,
+                            "position": 1,
                             "type": "item",
                             "link": "/pipeline/#/runs",
                             "text": "Runs",
@@ -351,6 +358,7 @@ class KfpUiOperator(CharmBase):
                         },
                         {
                             "app": self.app.name,
+                            "position": 1,
                             "type": "item",
                             "link": "/pipeline/#/recurringruns",
                             "text": "Recurring Runs",
@@ -360,6 +368,11 @@ class KfpUiOperator(CharmBase):
                 )
             }
         )
+
+    def _on_sidebar_relation_departed(self, event):
+        if not self.unit.is_leader():
+            return
+        event.relation.data[self.app].update({"config": json.dumps([])})
 
 
 class CheckFailedError(Exception):

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -13,7 +13,7 @@ from base64 import b64encode
 
 from jsonschema import ValidationError
 from oci_image import OCIImageResource, OCIImageResourceError
-from ops.charm import CharmBase
+from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import (
@@ -46,6 +46,7 @@ class KfpUiOperator(CharmBase):
         self.framework.observe(self.on["ingress"].relation_changed, self._main)
         self.framework.observe(self.on["kfp-ui"].relation_changed, self._main)
         self.framework.observe(self.on.leader_elected, self._main)
+        self.framework.observe(self.on.sidebar_relation_joined, self._on_sidebar_relation_joined)
 
     def _main(self, event):
         try:
@@ -319,6 +320,46 @@ class KfpUiOperator(CharmBase):
             )
 
         return data_dict
+
+    def _on_sidebar_relation_joined(self, event: RelationJoinedEvent):
+        if not self.unit.is_leader():
+            return
+        event.relation.data[self.app].update(
+            {
+                "config": json.dumps(
+                    [
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "text": "Experiments (KFP)",
+                            "link": "/pipeline/#/experiments",
+                            "icon": "done-all",
+                        },
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "link": "/pipeline/#/pipelines",
+                            "text": "Pipelines",
+                            "icon": "kubeflow:pipeline-centered",
+                        },
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "link": "/pipeline/#/runs",
+                            "text": "Runs",
+                            "icon": "maps:directions-run",
+                        },
+                        {
+                            "app": self.app.name,
+                            "type": "item",
+                            "link": "/pipeline/#/recurringruns",
+                            "text": "Recurring Runs",
+                            "icon": "device:access-alarm",
+                        },
+                    ]
+                )
+            }
+        )
 
 
 class CheckFailedError(Exception):

--- a/tests/integration/data/kfp_against_latest_edge.yaml
+++ b/tests/integration/data/kfp_against_latest_edge.yaml
@@ -57,6 +57,7 @@ applications:
     channel: latest/edge
     charm: kubeflow-dashboard
     scale: 1
+    trust: true
   kubeflow-profiles:
     _github_repo_name: kubeflow-profiles-operator
     channel: latest/edge


### PR DESCRIPTION
Related to this [jira task](https://warthogs.atlassian.net/browse/KF-567?atlOrigin=eyJpIjoiN2M3MjQwZmY2NzEwNGQwMTkzYThkZTNhMzU0YmFlNmUiLCJwIjoiaiJ9) and this [feature](https://github.com/canonical/kubeflow-dashboard-operator/issues/8)

In `kubeflow-dashboard-operator` there is a `sidebar` relation. In order to add element to the sidebar proper relation needs to be established. After the relation is set, charms fills the config for given app-name.

Sidebar element is removed after the relation is broken.