### PR TITLE
feat: bump track 1.6 to 1.6.1, fix CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.0.0-rc
+        uses: canonical/charming-actions/check-libraries@2.1.1
         with:
           credentials: "${{ secrets.charmcraft-credentials }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc
+        uses: canonical/charming-actions/channel@2.1.1
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.0.0-rc
+        uses: canonical/charming-actions/release-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/api-server:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/api-server:2.0.0-alpha.5
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.0-alpha.5
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -74,6 +74,12 @@ class KfpPersistenceOperator(CharmBase):
                                     "resources": ["scheduledworkflows"],
                                     "verbs": ["get", "list", "watch"],
                                 },
+                                {
+                                    "apiGroups": [""],
+                                    "resources": ["namespaces"],
+                                    "verbs": ["get"],
+                                },
+
                             ],
                         }
                     ]
@@ -90,10 +96,24 @@ class KfpPersistenceOperator(CharmBase):
                             "--numWorker=2",
                             f"--mlPipelineAPIServerName={kfpapi['service-name']}",
                         ],
+                        "envConfig": {
+                            "KUBEFLOW_USERID_HEADER": "kubeflow-userid",
+                            "KUBEFLOW_USERID_PREFIX": "",
+                        },
                     }
                 ],
             },
+            k8s_resources={
+                "kubernetesResources": {
+                    "configMaps": {
+                        "persistenceagent-config": {
+                            "params.env": "MULTIUSER=true",
+                        }
+                    }
+                }
+            },
         )
+
         self.model.unit.status = ActiveStatus()
 
     def _check_leader(self):

--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -79,7 +79,6 @@ class KfpPersistenceOperator(CharmBase):
                                     "resources": ["namespaces"],
                                     "verbs": ["get"],
                                 },
-
                             ],
                         }
                     ]

--- a/charms/kfp-profile-controller/README.md
+++ b/charms/kfp-profile-controller/README.md
@@ -1,4 +1,4 @@
-## Kubeflow Pipelines API Operator
+## Kubeflow Pipelines Profile Controller Operator
 
 ### Overview
 This charm encompasses the Kubernetes Python operator for Kubeflow Pipelines
@@ -6,7 +6,7 @@ Profile Controller (multi-user components of Kubeflow Pipelines) (see [CharmHub]
 
 ## Install
 
-To install Kubeflow Pipelines API, run:
+To install Kubeflow Pipelines Profile Controller, run:
 
     juju deploy kfp-profile-controller
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -46,14 +46,12 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
         entity_url="kubeflow-profiles",
-        # TODO: Revert once kubeflow-profiles stable supports k8s 1.22
-        channel="latest/edge",
+        channel="1.6/edge",
         trust=True,
     )
     await ops_test.model.deploy(
         entity_url="metacontroller-operator",
-        # TODO: Revert once metacontroller stable supports k8s 1.22
-        channel="latest/edge",
+        channel="1.6/edge",
         trust=True,
     )
 

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.0-alpha.5

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/frontend:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/frontend:2.0.0-alpha.5
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.0-alpha.5

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.0-alpha.5
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
This bumps kfp to the version released with the 1.6.1 Kubeflow release.  It also fixes CI to address backwards-incompatible changes that occurred to charmcraft, and pins tests to use `1.6/edge` rather than `latest/edge`.  