### PR TITLE
feat: bump track 2.0 to kfp released for KF 1.6.1, fix CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -92,6 +92,10 @@ jobs:
           provider: microk8s
           channel: 1.22/stable
           charmcraft-channel: latest/candidate
+          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
+          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
+          #       the "metrics-endpoint-relation-changed" hook.
+          bootstrap-options: --agent-version="2.9.34"
 
       # TODO: Remove once the actions-operator does this automatically
       - name: Configure kubectl
@@ -122,6 +126,8 @@ jobs:
           provider: microk8s
           channel: 1.22/stable
           charmcraft-channel: latest/candidate
+          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
+          bootstrap-options: --agent-version="2.9.34"
 
       # Required until https://github.com/charmed-kubernetes/actions-operator/pull/33 is merged
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.0.0-rc
+        uses: canonical/charming-actions/check-libraries@2.1.1
         with:
           credentials: "${{ secrets.charmcraft-credentials }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -138,7 +138,7 @@ jobs:
           # Remove destructive-mode once these bugs are fixed:
           # https://github.com/canonical/charmcraft/issues/554
           # https://github.com/canonical/craft-providers/issues/96
-          tox -e bundle-integration -- --model kubeflow --destructive-mode
+          tox -e bundle-integration -- --model kubeflow --destructive-mode --bundle ./tests/integration/data/kfp_against_1.6_edge.yaml
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc
+        uses: canonical/charming-actions/channel@2.1.1
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.0.0-rc
+        uses: canonical/charming-actions/release-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -5,7 +5,7 @@ applications:
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: latest/edge,       scale: 1 }
   kfp-api:                 { charm: ch:kfp-api, channel: latest/edge,                        scale: 1 }
-  kfp-db:                  { charm: cs:~charmed-osm/mariadb-k8s-35,    scale: 1, options: { database: mlpipeline } }
+  kfp-db:                  { charm: charmed-osm-mariadb-k8s, channel: latest/stable, scale: 1, options: { database: mlpipeline } }
   kfp-profile-controller:  { charm: ch:kfp-profile-controller, channel: latest/edge, scale: 1 }
   kfp-persistence:         { charm: ch:kfp-persistence, channel: latest/edge,                scale: 1 }
   kfp-schedwf:             { charm: ch:kfp-schedwf, channel: latest/edge,                    scale: 1 }

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/api-server:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/api-server:2.0.0-alpha.5
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.0-alpha.5
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -74,6 +74,11 @@ class KfpPersistenceOperator(CharmBase):
                                     "resources": ["scheduledworkflows"],
                                     "verbs": ["get", "list", "watch"],
                                 },
+                                {
+                                    "apiGroups": [""],
+                                    "resources": ["namespaces"],
+                                    "verbs": ["get"],
+                                },
                             ],
                         }
                     ]
@@ -90,6 +95,12 @@ class KfpPersistenceOperator(CharmBase):
                             "--numWorker=2",
                             f"--mlPipelineAPIServerName={kfpapi['service-name']}",
                         ],
+                        "envConfig": {
+                            "KUBEFLOW_USERID_HEADER": "kubeflow-userid",
+                            "KUBEFLOW_USERID_PREFIX": "",
+                            # Upstream defines this in the configmap persistenceagent-config-*
+                            "MULTIUSER": "true",
+                        },
                     }
                 ],
             },

--- a/charms/kfp-profile-controller/README.md
+++ b/charms/kfp-profile-controller/README.md
@@ -1,4 +1,4 @@
-## Kubeflow Pipelines API Operator
+## Kubeflow Pipelines Profile Controller Operator
 
 ### Overview
 This charm encompasses the Kubernetes Python operator for Kubeflow Pipelines
@@ -6,7 +6,7 @@ Profile Controller (multi-user components of Kubeflow Pipelines) (see [CharmHub]
 
 ## Install
 
-To install Kubeflow Pipelines API, run:
+To install Kubeflow Pipelines Profile Controller, run:
 
     juju deploy kfp-profile-controller
 

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.0-alpha.5

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/frontend:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/frontend:2.0.0-alpha.5
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.0-alpha.5

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -9,7 +9,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.0-alpha.3
+    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.0-alpha.5
 provides:
   kfp-viz:
     interface: k8s-service

--- a/tests/integration/data/kfp_against_1.6_edge.yaml
+++ b/tests/integration/data/kfp_against_1.6_edge.yaml
@@ -1,0 +1,101 @@
+applications:
+  argo-controller:
+    channel: 3.3/edge
+    charm: ch:argo-controller
+    scale: 1
+  istio-ingressgateway:
+    _github_repo_name: istio-operators
+    channel: 1.11/edge
+    charm: istio-gateway
+    options:
+      kind: ingress
+    scale: 1
+    trust: true
+  istio-pilot:
+    _github_repo_name: istio-operators
+    channel: 1.11/edge
+    charm: istio-pilot
+    options:
+      default-gateway: kubeflow-gateway
+    scale: 1
+    trust: true
+  kfp-api:
+    channel: latest/edge
+    charm: ch:kfp-api
+    scale: 1
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    channel: latest/edge
+    charm: ch:kfp-persistence
+    scale: 1
+  kfp-profile-controller:
+    channel: latest/edge
+    charm: ch:kfp-profile-controller
+    scale: 1
+  kfp-schedwf:
+    channel: latest/edge
+    charm: ch:kfp-schedwf
+    scale: 1
+  kfp-ui:
+    channel: latest/edge
+    charm: ch:kfp-ui
+    scale: 1
+  kfp-viewer:
+    channel: latest/edge
+    charm: ch:kfp-viewer
+    scale: 1
+  kfp-viz:
+    channel: latest/edge
+    charm: ch:kfp-viz
+    scale: 1
+  kubeflow-dashboard:
+    _github_repo_name: kubeflow-dashboard-operator
+    channel: 1.6/edge
+    charm: kubeflow-dashboard
+    scale: 1
+  kubeflow-profiles:
+    _github_repo_name: kubeflow-profiles-operator
+    channel: 1.6/edge
+    charm: kubeflow-profiles
+    scale: 1
+  metacontroller-operator:
+    channel: 2.0/edge
+    charm: ch:metacontroller-operator
+    scale: 1
+    trust: true
+  minio:
+    channel: ckf-1.6/edge
+    charm: ch:minio
+    scale: 1
+bundle: kubernetes
+name: kubeflow-pipelines
+relations:
+  - - kfp-api
+    - kfp-db
+  - - kfp-api:kfp-api
+    - kfp-persistence:kfp-api
+  - - kfp-api:kfp-api
+    - kfp-ui:kfp-api
+  - - kfp-api:kfp-viz
+    - kfp-viz:kfp-viz
+  - - kfp-api:object-storage
+    - minio:object-storage
+  - - kfp-profile-controller:object-storage
+    - minio:object-storage
+  - - kfp-ui:object-storage
+    - minio:object-storage
+  - - argo-controller:object-storage
+    - minio:object-storage
+  - - kubeflow-profiles
+    - kubeflow-dashboard
+  - - istio-pilot:ingress
+    - kubeflow-dashboard:ingress
+  - - istio-pilot:istio-pilot
+    - istio-ingressgateway:istio-pilot
+  - - istio-pilot:ingress
+    - kfp-ui:ingress

--- a/tests/integration/data/kfp_against_latest_edge.yaml
+++ b/tests/integration/data/kfp_against_latest_edge.yaml
@@ -24,10 +24,11 @@ applications:
     charm: ch:kfp-api
     scale: 1
   kfp-db:
-    charm: cs:~charmed-osm/mariadb-k8s-35
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
     options:
       database: mlpipeline
-    scale: 1
   kfp-persistence:
     channel: latest/edge
     charm: ch:kfp-persistence


### PR DESCRIPTION
This bumps kfp to the version released with the 1.6.1 Kubeflow release. It also fixes CI to address backwards-incompatible changes that occurred to charmcraft, and pins tests to use 1.6/edge rather than latest/edge.