### PR TITLE
fix: pin integration CI to juju agent-version=2.9.34

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -92,6 +92,10 @@ jobs:
           provider: microk8s
           channel: 1.22/stable
           charmcraft-channel: latest/candidate
+          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
+          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
+          #       the "metrics-endpoint-relation-changed" hook.
+          bootstrap-options: --agent-version="2.9.34"
 
       # TODO: Remove once the actions-operator does this automatically
       - name: Configure kubectl
@@ -122,6 +126,8 @@ jobs:
           provider: microk8s
           channel: 1.22/stable
           charmcraft-channel: latest/candidate
+          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
+          bootstrap-options: --agent-version="2.9.34"
 
       # Required until https://github.com/charmed-kubernetes/actions-operator/pull/33 is merged
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"


### PR DESCRIPTION
This is a temporary fix to address [this bug](https://bugs.launchpad.net/juju/+bug/1992833).  In particular, leaving the agent-version unpinned results in the kfp-api observability tests to fail with prometheus-k8s failing in either the stop hook or the metrics-endpoint-relation-changed hook