### PR TITLE
fix: bundle integration tests

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -5,7 +5,7 @@ applications:
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: latest/edge,       scale: 1 }
   kfp-api:                 { charm: ch:kfp-api, channel: latest/edge,                        scale: 1 }
-  kfp-db:                  { charm: cs:~charmed-osm/mariadb-k8s-35,    scale: 1, options: { database: mlpipeline } }
+  kfp-db:                  { charm: charmed-osm-mariadb-k8s, channel: latest/stable, scale: 1, options: { database: mlpipeline } }
   kfp-profile-controller:  { charm: ch:kfp-profile-controller, channel: latest/edge, scale: 1 }
   kfp-persistence:         { charm: ch:kfp-persistence, channel: latest/edge,                scale: 1 }
   kfp-schedwf:             { charm: ch:kfp-schedwf, channel: latest/edge,                    scale: 1 }

--- a/tests/integration/data/kfp_against_latest_edge.yaml
+++ b/tests/integration/data/kfp_against_latest_edge.yaml
@@ -57,6 +57,7 @@ applications:
     channel: latest/edge
     charm: kubeflow-dashboard
     scale: 1
+    trust: true
   kubeflow-profiles:
     _github_repo_name: kubeflow-profiles-operator
     channel: latest/edge

--- a/tests/integration/data/kfp_against_latest_edge.yaml
+++ b/tests/integration/data/kfp_against_latest_edge.yaml
@@ -24,10 +24,11 @@ applications:
     charm: ch:kfp-api
     scale: 1
   kfp-db:
-    charm: cs:~charmed-osm/mariadb-k8s-35
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
     options:
       database: mlpipeline
-    scale: 1
   kfp-persistence:
     channel: latest/edge
     charm: ch:kfp-persistence

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -54,6 +54,8 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
     cmd = f"juju deploy -m {model} --trust {bundle_dst_file}"
     log.info(f"Deploying bundle to {model} using cmd '{cmd}'")
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    if rc != 0:
+        raise RuntimeError(f"Failed to deploy bundle.  Got stdout:\n{stderr}\nand stderr:\n{stderr}")
 
     # Wait for everything to be up.  Note, at time of writing these charms would naturally go
     # into blocked during deploy while waiting for each other to satisfy relations, so we don't


### PR DESCRIPTION
This PR fixes two breaks in the bundle integration tests:
* kubeflow-dashboard has been refactored and now needs --trust.  This is added here
* an old mariadb charm was incorrectly being pulled from the charm store, silently causing errors.  This has been updated, and an error check added to catch bundle deploy errors more overtly in future.

This PR is based on #115.  #115 should be merged first.