### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,17 +15,66 @@ requires:
     interface: mysql
   object-storage:
     interface: object-storage
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
   kfp-viz:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
 provides:
   kfp-api:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -16,5 +16,17 @@ resources:
 requires:
   kfp-api:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -14,5 +14,30 @@ resources:
 requires:
   object-storage:
     interface: object-storage
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -13,18 +13,103 @@ resources:
 requires:
   object-storage:
     interface: object-storage
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
   kfp-api:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   ingress:
     interface: ingress
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
 provides:
   kfp-ui:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -13,5 +13,17 @@ resources:
 provides:
   kfp-viz:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml

--- a/tests/integration/data/kfp_against_latest_edge.yaml
+++ b/tests/integration/data/kfp_against_latest_edge.yaml
@@ -64,6 +64,7 @@ applications:
     channel: latest/edge
     charm: kubeflow-profiles
     scale: 1
+    trust: true
   metacontroller-operator:
     channel: latest/edge
     charm: ch:metacontroller-operator


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).

Also fixed here is the integration CI for kfp-profile-controller.  This CI has been refactored to improve robustness to address flaky failures.