### PR TITLE
tests: pin python-libjuju<3.1 to avoid unsupported version errors

### DIFF
--- a/charms/kfp-api/requirements-integration.in
+++ b/charms/kfp-api/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire

--- a/charms/kfp-persistence/requirements-integration.in
+++ b/charms/kfp-persistence/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire

--- a/charms/kfp-profile-controller/requirements-integration.in
+++ b/charms/kfp-profile-controller/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 lightkube
 pytest-operator
 selenium

--- a/charms/kfp-schedwf/requirements-integration.in
+++ b/charms/kfp-schedwf/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire

--- a/charms/kfp-ui/requirements-integration.in
+++ b/charms/kfp-ui/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire

--- a/charms/kfp-viewer/requirements-integration.in
+++ b/charms/kfp-viewer/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire

--- a/charms/kfp-viz/requirements-integration.in
+++ b/charms/kfp-viz/requirements-integration.in
@@ -1,4 +1,4 @@
-juju
+juju<3.1
 pytest-operator
 selenium
 selenium-wire


### PR DESCRIPTION
Apparently the juju agent 2.9.34 is not compatible with pythonlib-juju 3.1, causing the following error:
juju.errors.JujuConnectionError: juju server-version 2.9.34 not supported To avoid this, we have to pin to a version below 3.1.