### PR TITLE
refactor: use get_relation and data to get relation data from myql relation

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -289,6 +289,14 @@ class KfpApiOperator(CharmBase):
         return interfaces
 
     def _get_mysql(self):
+        """Returns mysql relation data from the relation with a mysql database.
+
+        Raises:
+            CheckFailedError in the following scenarios:
+                1. If there is no mysql relation, which will block the unit
+                2. If The remove unit has not joined the relation, will set unit to WaitingStatus
+                3. If the relation data bag is empty, will set unit to WaitingStatus
+        """
         mysql_relation = self.model.get_relation("mysql")
 
         # Raise exception and stop execution if the mysql relation is not established
@@ -311,6 +319,8 @@ class KfpApiOperator(CharmBase):
         mysql_relation_data = mysql_relation.data[kfp_db_unit]
 
         # Check if the relation data contains the expected attributes
+        # mysql_relation_data may contain more than these attributes, but
+        # we are interested in the data bag containing at least the following:
         expected_attributes = ["database", "host", "root_password", "port"]
         missing_attributes = [
             attribute for attribute in expected_attributes if attribute not in mysql_relation_data

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -311,9 +311,11 @@ class KfpApiOperator(CharmBase):
         # This charm should only establish a relation with exactly one unit
         # the following extracts exactly one unit from the set that's
         # returned by mysql_relation.data
-        for unit in mysql_relation.units:
-            # Get mysql relation data
-            mysql_relation_data = mysql_relation.data[unit]
+        units = mysql_relation.units
+        kfp_db_unit = list(units)[0]
+
+        # Get mysql relation data
+        mysql_relation_data = mysql_relation.data[kfp_db_unit]
 
         # Check if the relation data contains the expected attributes
         # mysql_relation_data may contain more than these attributes, but

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -326,7 +326,7 @@ class KfpApiOperator(CharmBase):
         ]
 
         if missing_attributes:
-            self.log.exception(
+            self.log.error(
                 f"mysql relation data missing expected attributes '{missing_attributes}'"
             )
             raise CheckFailedError(

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -300,7 +300,7 @@ class KfpApiOperator(CharmBase):
 
         # Raise exception and stop execution if the mysql relation is not established
         if not mysql_relation:
-            raise CheckFailedError("There is no mysql relation", BlockedStatus)
+            raise CheckFailedError("Add mysql relation", BlockedStatus)
 
         if not mysql_relation.units:
             raise CheckFailedError("Waiting for remote unit to join relation", WaitingStatus)

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -292,10 +292,9 @@ class KfpApiOperator(CharmBase):
         """Returns mysql relation data from the relation with a mysql database.
 
         Raises:
-            CheckFailedError in the following scenarios:
-                1. If there is no mysql relation, which will block the unit
-                2. If The remove unit has not joined the relation, will set unit to WaitingStatus
-                3. If the relation data bag is empty, will set unit to WaitingStatus
+            CheckFailed(..., BlockedStatus) if there is no mysql relation
+            CheckFailed(..., WaitingStatus) if The remove unit has not joined the relation
+            CheckFailed(..., WaitingStatus) if the relation data bag is empty
         """
         mysql_relation = self.model.get_relation("mysql")
 

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -311,11 +311,9 @@ class KfpApiOperator(CharmBase):
         # This charm should only establish a relation with exactly one unit
         # the following extracts exactly one unit from the set that's
         # returned by mysql_relation.data
-        units = mysql_relation.units
-        kfp_db_unit = list(units)[0]
-
-        # Get mysql relation data
-        mysql_relation_data = mysql_relation.data[kfp_db_unit]
+        for unit in mysql_relation.units:
+            # Get mysql relation data
+            mysql_relation_data = mysql_relation.data[unit]
 
         # Check if the relation data contains the expected attributes
         # mysql_relation_data may contain more than these attributes, but

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -7,7 +7,7 @@ import ops
 import pytest
 import yaml
 from oci_image import MissingResourceError
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, TooManyRelatedAppsError, WaitingStatus
 from ops.testing import Harness
 
 from charm import CheckFailedError, KfpApiOperator
@@ -109,10 +109,8 @@ def test_mysql_relation_too_many_relations(harness):
     rel_id_2 = harness.add_relation("mysql", "extra_sql")
     harness.add_relation_unit(rel_id_2, "extra_sql/0")
 
-    with pytest.raises(CheckFailedError) as too_many_relations:
+    with pytest.raises(TooManyRelatedAppsError) as too_many_relations:
         harness.charm._get_mysql()
-    assert too_many_relations.value.status == BlockedStatus("Too many mysql relations")
-
 
 def test_kfp_viz_relation_missing(harness):
     harness.set_leader()

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -109,8 +109,9 @@ def test_mysql_relation_too_many_relations(harness):
     rel_id_2 = harness.add_relation("mysql", "extra_sql")
     harness.add_relation_unit(rel_id_2, "extra_sql/0")
 
-    with pytest.raises(TooManyRelatedAppsError) as too_many_relations:
+    with pytest.raises(TooManyRelatedAppsError):
         harness.charm._get_mysql()
+
 
 def test_kfp_viz_relation_missing(harness):
     harness.set_leader()


### PR DESCRIPTION
The previous way of retrieving relation data from the `mysql` relation caused issues when there no remote unit joined the relation, or the relation data bag was empty (see more details of this issue in #163). Refactoring the method that retrieves relation data prevents this from happening.

Failing integration tests will be fixed by #177 and #178, please merge only after those two PRs are also merged. 

This, along with changes in #177 and #178  have been tested together [here](https://github.com/canonical/kfp-operators/actions/runs/4509420822). We can merge this PR in the dev branch to later merge it into main.