### PR TITLE
ci: bump juju agent 2.9.34 -> 2.9.42

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -92,10 +92,8 @@ jobs:
           provider: microk8s
           channel: 1.24/stable
           charmcraft-channel: latest/candidate
-          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
-          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
-          #       the "metrics-endpoint-relation-changed" hook.
-          bootstrap-options: --agent-version="2.9.34"
+          # Pinning juju agent to 2.9.42 to keep compatibility with pythonlib-juju<3
+          bootstrap-options: --agent-version="2.9.42"
 
       # TODO: Remove once the actions-operator does this automatically
       - name: Configure kubectl
@@ -126,8 +124,8 @@ jobs:
           provider: microk8s
           channel: 1.24/stable
           charmcraft-channel: latest/candidate
-          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
-          bootstrap-options: --agent-version="2.9.34"
+          # Pinning juju agent to 2.9.42 to keep compatibility with pythonlib-juju<3
+          bootstrap-options: --agent-version="2.9.42"
 
       # Required until https://github.com/charmed-kubernetes/actions-operator/pull/33 is merged
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"


### PR DESCRIPTION
The juju agent 2.9.42 should fix https://bugs.launchpad.net/juju/+bug/1992833.

Expected CI failures:
* `application-kfp-api: 22:03:48 ERROR unit.kfp-api/0.juju-log kfp-viz:18: Encountered the following exception when parsing mysql relation: list index out of range` or similar. This will be fixed in https://github.com/canonical/kfp-operators/pull/176

This, along with changes in #178  and #176 have been tested together [here](https://github.com/canonical/kfp-operators/actions/runs/4509420822). We can merge this PR in the dev branch to later merge it into main.