### PR TITLE
tests: increase timeout for waiting obs charms to be active

### DIFF
--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -82,7 +82,7 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
         f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
     )
 
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
+    await ops_test.model.wait_for_idle(status="active", timeout=90 * 20)
 
     status = await ops_test.model.get_status()
     prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]


### PR DESCRIPTION
Observability charms need more time to be deployed in Github runners.

Merge after #177 

Expected CI failures:
* `application-kfp-api: 22:03:48 ERROR unit.kfp-api/0.juju-log kfp-viz:18: Encountered the following exception when parsing mysql relation: list index out of range` or similar. This will be fixed in #176 
* Timeouts when deploying grafana and/or prometheus. This will be fixed in #177 

This, along with changes in #177 and #176 have been tested together [here](https://github.com/canonical/kfp-operators/actions/runs/4509420822). We can merge this PR in the dev branch to later merge it into main.