### PR TITLE
ci: bump charming-actions 2.2.3->2.2.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.3
+        uses: canonical/charming-actions/channel@2.2.4
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.3
+        uses: canonical/charming-actions/upload-charm@2.2.4
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump charming-actions@2.2.4

Publish actions will fail until the new version of charming-actions is [released](https://github.com/canonical/charming-actions/releases).