### PR TITLE
pebble: Sleep before starting KFP API server

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm the Kubeflow Pipelines API.
@@ -67,6 +67,9 @@ class KfpApiOperator(CharmBase):
         self._grcp_port = self.model.config["grpc-port"]
         self._http_port = self.model.config["http-port"]
         self._exec_command = (
+            # TODO: Remove 'sleep' as soon as a fix for
+            # https://github.com/canonical/pebble/issues/240 is provided
+            "sleep 1.1 && "
             "/bin/apiserver "
             f"--config={CONFIG_DIR} "
             f"--sampleconfig={SAMPLE_CONFIG} "
@@ -184,7 +187,7 @@ class KfpApiOperator(CharmBase):
                 self._container_name: {
                     "override": "replace",
                     "summary": "ML Pipeline API Server",
-                    "command": self._exec_command,
+                    "command": f"bash -c '{self._exec_command}'",
                     "startup": "enabled",
                     "environment": self.service_environment,
                     "on-check-failure": {"kfp-api-up": "restart"},

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from contextlib import nullcontext as does_not_raise
@@ -418,12 +418,17 @@ class TestCharm:
         assert pebble_plan
         assert pebble_plan.services
         pebble_plan_info = pebble_plan.to_dict()
-        assert pebble_plan_info["services"]["ml-pipeline-api-server"]["command"] == (
+        pebble_exec_command = pebble_plan_info["services"]["ml-pipeline-api-server"]["command"]
+        exec_command = (
+            # TODO: Remove 'sleep' as soon as a fix for
+            # https://github.com/canonical/pebble/issues/240 is provided
+            "sleep 1.1 && "
             "/bin/apiserver "
             "--config=/config "
             "--sampleconfig=/config/sample_config.json "
             "-logtostderr=true "
         )
+        assert pebble_exec_command == f"bash -c '{exec_command}'"
         test_env = pebble_plan_info["services"]["ml-pipeline-api-server"]["environment"]
         # there should be 1 environment variable
         assert 1 == len(test_env)


### PR DESCRIPTION
Sleep for 1 second before attempting to start the KFP API server, in order to avoid issues with Pebble when the corresponding service fails fast. This is a temporary measure until a fix for canonical/pebble#240 is provided.

Refs #220