### PR TITLE
[DEMO] pre-built charms as reusable artefacts in different GH workflow jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,8 +83,8 @@ jobs:
   
       - name: Run E2E Tests
         uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
-       with:
-           packed-charms: ${{ needs.build-charms.outputs.charms }}
+        with:
+          packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   publish-on-success:
     # publish on push to main or track/** only if all tests pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,23 +53,23 @@ jobs:
 
   individual-integration-tests:
    name: Individual Integration Tests 
-   needs: [build-charms, quality-checks, unit-tests]
-   matrix:
-     charm:
-       - kfp-api
-       - kfp-profile-controller
-   steps:
-     - name: Download packed charm(s)
-       uses: actions/download-artifact@v3
-       with:
-         name: ${{ needs.build-charms.outputs.artifact-name }}
-  
-     - name: Individual Integration Tests
-       uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
-       secrets: inherit
-       with:
-         charm-name: ${{ matrix.charm }}
-         packed-charms: ${{ needs.build-charms.outputs.charms }}
+     needs: [build-charms, quality-checks, unit-tests]
+     matrix:
+       charm:
+         - kfp-api
+         - kfp-profile-controller
+     steps:
+       - name: Download packed charm(s)
+         uses: actions/download-artifact@v3
+         with:
+           name: ${{ needs.build-charms.outputs.artifact-name }}
+    
+       - name: Individual Integration Tests
+         uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+         secrets: inherit
+         with:
+           charm-name: ${{ matrix.charm }}
+           packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   e2e-tests:
     name: E2E Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
     - track/**
 
 jobs:
-  build:
+  build-charms:
   name: Build charms
   uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
@@ -52,37 +52,39 @@ jobs:
       charm-name: ${{ matrix.charm }}
 
   individual-integration-tests:
+   name: Individual Integration Tests 
+   needs: [build-charms, quality-checks, unit-tests]
+     matrix:
+       charm:
+         - kfp-api
+         - kfp-profile-controller
    steps:
      - name: Download packed charm(s)
        uses: actions/download-artifact@v3
        with:
-         name: ${{ needs.build.outputs.artifact-name }}
+         name: ${{ needs.build-charms.outputs.artifact-name }}
   
       - name: Individual Integration Tests
-        needs: [quality-checks, unit-tests]
-        strategy:
-          matrix:
-            charm:
-              - kfp-api
-              - kfp-profile-controller
         uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
         secrets: inherit
         with:
           charm-name: ${{ matrix.charm }}
-          packed-charms: ${{ needs.build.outputs.charms }}
+          packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   e2e-tests:
+    name: E2E Tests
+    needs: [build-charms, quality-checks, unit-tests]
+
     steps:
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.build.outputs.artifact-name }}
+          name: ${{ needs.build-charms.outputs.artifact-name }}
   
-      - name: E2E Tests
-       needs: [quality-checks, unit-tests]
-       uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
+      - name: Run E2E Tests
+        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
        with:
-           packed-charms: ${{ needs.build.outputs.charms }}
+           packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   publish-on-success:
     # publish on push to main or track/** only if all tests pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,22 +54,22 @@ jobs:
   individual-integration-tests:
    name: Individual Integration Tests 
    needs: [build-charms, quality-checks, unit-tests]
-     matrix:
-       charm:
-         - kfp-api
-         - kfp-profile-controller
+   matrix:
+     charm:
+       - kfp-api
+       - kfp-profile-controller
    steps:
      - name: Download packed charm(s)
        uses: actions/download-artifact@v3
        with:
          name: ${{ needs.build-charms.outputs.artifact-name }}
   
-      - name: Individual Integration Tests
-        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
-        secrets: inherit
-        with:
-          charm-name: ${{ matrix.charm }}
-          packed-charms: ${{ needs.build-charms.outputs.charms }}
+     - name: Individual Integration Tests
+       uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+       secrets: inherit
+       with:
+         charm-name: ${{ matrix.charm }}
+         packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   e2e-tests:
     name: E2E Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,10 @@ on:
     - track/**
 
 jobs:
+  build:
+  name: Build charms
+  uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
+
   quality-checks:
     name: Quality Checks
     strategy:
@@ -48,22 +52,35 @@ jobs:
       charm-name: ${{ matrix.charm }}
 
   individual-integration-tests:
-    name: Individual Integration Tests
-    needs: [quality-checks, unit-tests]
-    strategy:
-      matrix:
-        charm:
-          - kfp-api
-          - kfp-profile-controller
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@v1
-    secrets: inherit
-    with:
-      charm-name: ${{ matrix.charm }}
+   - name: Download packed charm(s)
+     uses: actions/download-artifact@v3
+     with:
+       name: ${{ needs.build.outputs.artifact-name }}
+
+    - name: Individual Integration Tests
+      needs: [quality-checks, unit-tests]
+      strategy:
+        matrix:
+          charm:
+            - kfp-api
+            - kfp-profile-controller
+      uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+      secrets: inherit
+      with:
+        charm-name: ${{ matrix.charm }}
+        packed-charms: ${{ needs.build.outputs.charms }}
 
   e2e-tests:
-    name: E2E Tests
-    needs: [quality-checks, unit-tests]
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@v1
+    - name: Download packed charm(s)
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.build.outputs.artifact-name }}
+
+    - name: E2E Tests
+     needs: [quality-checks, unit-tests]
+     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
+     with:
+         packed-charms: ${{ needs.build.outputs.charms }}
 
   publish-on-success:
     # publish on push to main or track/** only if all tests pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   build-charms:
-  name: Build charms
-  uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
+    name: Build charms
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
   quality-checks:
     name: Quality Checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,11 @@ jobs:
   individual-integration-tests:
     name: Individual Integration Tests 
     needs: [build-charms, quality-checks, unit-tests]
-    matrix:
-      charm:
-        - kfp-api
-        - kfp-profile-controller
+    strategy:
+      matrix:
+        charm:
+          - kfp-api
+          - kfp-profile-controller
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
     secrets: inherit
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,24 +52,24 @@ jobs:
       charm-name: ${{ matrix.charm }}
 
   individual-integration-tests:
-   name: Individual Integration Tests 
-     needs: [build-charms, quality-checks, unit-tests]
-     matrix:
-       charm:
-         - kfp-api
-         - kfp-profile-controller
-     steps:
-       - name: Download packed charm(s)
-         uses: actions/download-artifact@v3
-         with:
-           name: ${{ needs.build-charms.outputs.artifact-name }}
+    name: Individual Integration Tests 
+    needs: [build-charms, quality-checks, unit-tests]
+    matrix:
+      charm:
+        - kfp-api
+        - kfp-profile-controller
+    steps:
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build-charms.outputs.artifact-name }}
     
-       - name: Individual Integration Tests
-         uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
-         secrets: inherit
-         with:
-           charm-name: ${{ matrix.charm }}
-           packed-charms: ${{ needs.build-charms.outputs.charms }}
+      - name: Individual Integration Tests
+        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+        secrets: inherit
+        with:
+          charm-name: ${{ matrix.charm }}
+          packed-charms: ${{ needs.build-charms.outputs.charms }}
 
   e2e-tests:
     name: E2E Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,35 +52,37 @@ jobs:
       charm-name: ${{ matrix.charm }}
 
   individual-integration-tests:
-   - name: Download packed charm(s)
-     uses: actions/download-artifact@v3
-     with:
-       name: ${{ needs.build.outputs.artifact-name }}
-
-    - name: Individual Integration Tests
-      needs: [quality-checks, unit-tests]
-      strategy:
-        matrix:
-          charm:
-            - kfp-api
-            - kfp-profile-controller
-      uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
-      secrets: inherit
-      with:
-        charm-name: ${{ matrix.charm }}
-        packed-charms: ${{ needs.build.outputs.charms }}
+   steps:
+     - name: Download packed charm(s)
+       uses: actions/download-artifact@v3
+       with:
+         name: ${{ needs.build.outputs.artifact-name }}
+  
+      - name: Individual Integration Tests
+        needs: [quality-checks, unit-tests]
+        strategy:
+          matrix:
+            charm:
+              - kfp-api
+              - kfp-profile-controller
+        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+        secrets: inherit
+        with:
+          charm-name: ${{ matrix.charm }}
+          packed-charms: ${{ needs.build.outputs.charms }}
 
   e2e-tests:
-    - name: Download packed charm(s)
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ needs.build.outputs.artifact-name }}
-
-    - name: E2E Tests
-     needs: [quality-checks, unit-tests]
-     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
-     with:
-         packed-charms: ${{ needs.build.outputs.charms }}
+    steps:
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+  
+      - name: E2E Tests
+       needs: [quality-checks, unit-tests]
+       uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
+       with:
+           packed-charms: ${{ needs.build.outputs.charms }}
 
   publish-on-success:
     # publish on push to main or track/** only if all tests pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
     secrets: inherit
     with:
       charm-name: ${{ matrix.charm }}
-      packed-charms: ${{ needs.build-charms.outputs.charms }}
+      packed-charms: ${{ fromJSON(needs.build-charms.outputs.charms) }}
       charms-artefact-name: ${{ needs.build-charms.outputs.artifact-name }}
 
   e2e-tests:
@@ -71,7 +71,7 @@ jobs:
     needs: [build-charms, quality-checks, unit-tests]
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
     with:
-      packed-charms: ${{ needs.build-charms.outputs.charms }}
+      packed-charms: ${{ fromJSON(needs.build-charms.outputs.charms) }}
       charms-artefact-name: ${{ needs.build-charms.outputs.artifact-name }}
 
   publish-on-success:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,33 +58,20 @@ jobs:
       charm:
         - kfp-api
         - kfp-profile-controller
-    steps:
-      - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build-charms.outputs.artifact-name }}
-    
-      - name: Individual Integration Tests
-        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
-        secrets: inherit
-        with:
-          charm-name: ${{ matrix.charm }}
-          packed-charms: ${{ needs.build-charms.outputs.charms }}
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_integration-tests.yaml@dnplas-reusable-builds
+    secrets: inherit
+    with:
+      charm-name: ${{ matrix.charm }}
+      packed-charms: ${{ needs.build-charms.outputs.charms }}
+      charms-artefact-name: ${{ needs.build-charms.outputs.artifact-name }}
 
   e2e-tests:
     name: E2E Tests
     needs: [build-charms, quality-checks, unit-tests]
-
-    steps:
-      - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build-charms.outputs.artifact-name }}
-  
-      - name: Run E2E Tests
-        uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
-        with:
-          packed-charms: ${{ needs.build-charms.outputs.charms }}
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_bundle.yaml@dnplas-reusable-builds
+    with:
+      packed-charms: ${{ needs.build-charms.outputs.charms }}
+      charms-artefact-name: ${{ needs.build-charms.outputs.artifact-name }}
 
   publish-on-success:
     # publish on push to main or track/** only if all tests pass

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,1 +1,0 @@
-type: bundle

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -20,6 +20,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
 KFP_DB_CONFIG = {"database": "mlpipeline"}
 
+
 @pytest.fixture
 def ops_test(ops_test: OpsTest) -> OpsTest:
     if os.environ.get("CI") == "true":

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,24 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
 KFP_DB_CONFIG = {"database": "mlpipeline"}
+
+@pytest.fixture
+def ops_test(ops_test: OpsTest) -> OpsTest:
+    if os.environ.get("CI") == "true":
+        # Running in GitHub Actions; skip build step
+        # (GitHub Actions uses a separate, cached build step)
+        packed_charms = json.loads(os.environ["CI_PACKED_CHARMS"])
+
+        async def build_charm(charm_path, bases_index: int = None) -> Path:
+            for charm in packed_charms:
+                if Path(charm_path) == Path(charm["directory_path"]):
+                    if bases_index is None or bases_index == charm["bases_index"]:
+                        return charm["file_path"]
+            raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
+
+        ops_test.build_charm = build_charm
+
+    return ops_test
 
 
 class TestCharm:

--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -72,6 +72,9 @@ deps =
 description = Run unit tests
 
 [testenv:integration]
+pass_env =
+    CI
+    CI_PACKED_CHARMS
 commands = pytest -vv --tb native --asyncio-mode=auto {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -24,6 +24,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 MINIO_APP_NAME = "minio"
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
 
+
 @pytest.fixture
 def ops_test(ops_test: OpsTest) -> OpsTest:
     if os.environ.get("CI") == "true":

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,7 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
+import os
 from base64 import b64decode
 from pathlib import Path
 
@@ -21,6 +23,24 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 MINIO_APP_NAME = "minio"
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
+
+@pytest.fixture
+def ops_test(ops_test: OpsTest) -> OpsTest:
+    if os.environ.get("CI") == "true":
+        # Running in GitHub Actions; skip build step
+        # (GitHub Actions uses a separate, cached build step)
+        packed_charms = json.loads(os.environ["CI_PACKED_CHARMS"])
+
+        async def build_charm(charm_path, bases_index: int = None) -> Path:
+            for charm in packed_charms:
+                if Path(charm_path) == Path(charm["directory_path"]):
+                    if bases_index is None or bases_index == charm["bases_index"]:
+                        return charm["file_path"]
+            raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
+
+        ops_test.build_charm = build_charm
+
+    return ops_test
 
 
 @pytest.mark.abort_on_fail

--- a/charms/kfp-profile-controller/tox.ini
+++ b/charms/kfp-profile-controller/tox.ini
@@ -72,6 +72,9 @@ deps =
 description = Run unit tests
 
 [testenv:integration]
+pass_env =
+    CI
+    CI_PACKED_CHARMS
 commands = pytest -vv --tb native --asyncio-mode=auto {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,33 @@
 from _pytest.config.argparsing import Parser
 
+import json
+import os
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_operator.plugin import OpsTest
+log = logging.getLogger(__name__)
+
+@pytest.fixture
+def ops_test(ops_test: OpsTest) -> OpsTest:
+    if os.environ.get("CI") == "true":
+        # Running in GitHub Actions; skip build step
+        # (GitHub Actions uses a separate, cached build step)
+        packed_charms = json.loads(os.environ["CI_PACKED_CHARMS"])
+
+        async def build_charm(charm_path, bases_index: int = None) -> Path:
+            for charm in packed_charms:
+                if Path(charm_path) == Path(charm["directory_path"]):
+                    if bases_index is None or bases_index == charm["bases_index"]:
+                        file_path = Path(charm["file_path"].strip("local:"))
+                        return file_path
+            raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
+
+        ops_test.build_charm = build_charm
+
+    return ops_test
+
 
 def pytest_addoption(parser: Parser):
     parser.addoption(

--- a/tests/integration/helpers/localize_bundle.py
+++ b/tests/integration/helpers/localize_bundle.py
@@ -73,7 +73,7 @@ def localize_bundle_application(
         if not resources:
             resources = get_resources_from_charm_dir(charm_dir)
 
-    bundle["applications"][application]["charm"] = str(charm_file)
+    bundle["applications"][application]["charm"] = f"./{charm_file}"
     bundle["applications"][application]["resources"] = resources
     bundle["applications"][application]["_channel"] = bundle["applications"][application][
         "channel"

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ deps =
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:bundle-integration]
-commands = pytest -vv --tb=native -s {posargs} {[vars]tst_path}/integration
+pass_env =
+    CI
+    CI_PACKED_CHARMS
+commands = pytest -v --tb=native -s {posargs} {[vars]tst_path}/integration
 deps = 
     -r requirements-integration.txt


### PR DESCRIPTION
Use data-platform-workloads' [build_with_cache](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/build_charms_with_cache.yaml) action for speeding up charm builds and reuse charm files across different jobs.