### PR TITLE
tests: split kfp-api's integration tests into database and obs integration

### DIFF
--- a/charms/kfp-api/tests/integration/test_observability_integration.py
+++ b/charms/kfp-api/tests/integration/test_observability_integration.py
@@ -1,0 +1,140 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import requests
+import yaml
+from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_attempt, stop_after_delay, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "kfp-api"
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
+KFP_DB_CONFIG = {"database": "mlpipeline"}
+
+
+class TestCharm:
+    """Integration test charm"""
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test: OpsTest):
+        """Deploy kfp-api with required charms and relations."""
+        built_charm_path = await ops_test.build_charm("./")
+        logger.info(f"Built charm {built_charm_path}")
+
+        image_path = METADATA["resources"]["oci-image"]["upstream-source"]
+        resources = {"oci-image": image_path}
+
+        await ops_test.model.deploy(
+            entity_url=built_charm_path,
+            application_name=APP_NAME,
+            resources=resources,
+            trust=True,
+        )
+
+        await ops_test.model.deploy(
+            entity_url="minio", config=MINIO_CONFIG, channel="ckf-1.7/stable", trust=True
+        )
+        await ops_test.model.deploy(entity_url="kfp-viz", channel="2.0/stable", trust=True)
+
+        # deploy mysql-k8s charm
+        await ops_test.model.deploy(
+            "mysql-k8s",
+            channel="8.0/edge",
+            series="jammy",
+            constraints="mem=600M",
+            trust=True,
+        )
+
+        await ops_test.model.add_relation(f"{APP_NAME}:relational-db", "kfp-db:database")
+        await ops_test.model.add_relation(f"{APP_NAME}:object-storage", "minio:object-storage")
+        await ops_test.model.add_relation(f"{APP_NAME}:kfp-viz", "kfp-viz:kfp-viz")
+
+        await ops_test.model.wait_for_idle(
+            apps=["mysql-k8s"],
+            status="active",
+            raise_on_blocked=True,
+            timeout=60 * 10,
+            idle_period=60,
+        )
+
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, "kfp-viz", "kfp-db", "minio"],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 10,
+            idle_period=120,
+        )
+
+    async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
+        """Deploy prometheus, grafana and required relations, then test the metrics."""
+        prometheus = "prometheus-k8s"
+        grafana = "grafana-k8s"
+        prometheus_scrape = "prometheus-scrape-config-k8s"
+        scrape_config = {"scrape_interval": "30s"}
+
+        # Deploy and relate prometheus
+        await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(grafana, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(
+            prometheus_scrape, channel="latest/stable", config=scrape_config, trust=True
+        )
+
+        await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
+        await ops_test.model.add_relation(
+            f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+        )
+
+        await ops_test.model.wait_for_idle(
+            apps=["grafana-k8s", "prometheus-k8s", "prometheus-scrape-config-k8s"],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 20,
+            idle_period=60,
+        )
+
+        status = await ops_test.model.get_status()
+        prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
+            "address"
+        ]
+        logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
+
+        for attempt in self.retry_for_5_attempts:
+            logger.info(
+                f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
+            )
+            with attempt:
+                r = requests.get(
+                    f"http://{prometheus_unit_ip}:9090/api/v1/query?"
+                    f'query=up{{juju_application="{APP_NAME}"}}'
+                )
+                response = json.loads(r.content.decode("utf-8"))
+                response_status = response["status"]
+                logger.info(f"Response status is {response_status}")
+                assert response_status == "success"
+
+                response_metric = response["data"]["result"][0]["metric"]
+                assert response_metric["juju_application"] == APP_NAME
+                assert response_metric["juju_model"] == ops_test.model_name
+
+    # Helper to retry calling a function over 30 seconds or 5 attempts
+    retry_for_5_attempts = Retrying(
+        stop=(stop_after_attempt(5) | stop_after_delay(30)),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )


### PR DESCRIPTION
To avoid mixing scenarios and conditions that may affect the tests, specially when asserting for a blocked status after configuring the charm in a certain way, this commit splits the integration test file into two test suites that group related test cases: one for observability and another one for databases.
This PR is also pinning the mysql-k8s version to `8.0/edge` and increasing the constraints to 600M as recommended by the Data Platforms team.
Additionally, in the observability integration test suite, the mariadb charm is replaced with `mysql-k8s` just for correctness, as kfp-operators and Charmed Kubeflow will soon only use this charm as database.

#### TODO:
- [ ] Add observability integration tests to tox and CI workflow