### PR TITLE
[DO NOT MERGE][DEMO `main`]pre-built charms as reusable artefacts in different GH workflow jobs

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,6 +8,10 @@ on:
         required: true
 
 jobs:
+  build:
+    name: Build charms
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
+
   lib-check:
     name: Check libraries
     strategy:
@@ -63,44 +67,10 @@ jobs:
       - run: python3 -m pip install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
-  integration:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        charm:
-          - kfp-profile-controller
-          - kfp-api
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-          channel: 1.24/stable
-          juju-channel: 2.9/stable
-          charmcraft-channel: latest/candidate
-
-      # TODO: Remove once the actions-operator does this automatically
-      - name: Configure kubectl
-        run: |
-          sg microk8s -c "microk8s config > ~/.kube/config"
-
-      - run: |
-          sg microk8s -c "tox -e ${{ matrix.charm }}-integration"
-
-      # Collect debug logs if failed
-      - name: Dump Juju/k8s logs on failure
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: ${{ matrix.charm }}
-          model: testing
-
   test-bundle:
     name: Test the bundle
     runs-on: ubuntu-20.04
+    needs: build
 
     steps:
       - name: Check out code
@@ -110,30 +80,21 @@ jobs:
         with:
           provider: microk8s
           channel: 1.24/stable
-          juju-channel: 2.9/stable
+          microk8s-addons: "dns hostpath-storage rbac metallb:'10.64.140.43-10.64.140.49'"
           charmcraft-channel: latest/candidate
+          juju-channel: 2.9/stable
 
-      # TODO: Remove once https://bugs.launchpad.net/juju/+bug/2024897 is fixed
-      - name: Refresh Juju snap
-        run: |
-          sudo snap refresh juju --revision 22345
-
-      # Required until https://github.com/charmed-kubernetes/actions-operator/pull/33 is merged
-      - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
-
-      # TODO: Remove once the actions-operator does this automatically
-      - name: Configure kubectl
-        run: |
-          sg microk8s -c "microk8s config > ~/.kube/config"
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
 
       - name: Run test
         run: |
-          # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
-          # Remove destructive-mode once these bugs are fixed:
-          # https://github.com/canonical/charmcraft/issues/554
-          # https://github.com/canonical/craft-providers/issues/96
-          tox -e bundle-integration -- --model kubeflow --destructive-mode
+          tox -e bundle-integration -- --model kubeflow
+        env:
+            CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -84,6 +84,11 @@ jobs:
           charmcraft-channel: latest/candidate
           juju-channel: 2.9/stable
 
+      # TODO: Remove once https://bugs.launchpad.net/juju/+bug/2024897 is fixed
+      - name: Refresh Juju snap
+        run: |
+          sudo snap refresh juju --revision 22345
+
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,1 +1,0 @@
-type: bundle

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,33 @@
 from _pytest.config.argparsing import Parser
 
+import json
+import os
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_operator.plugin import OpsTest
+log = logging.getLogger(__name__)
+
+@pytest.fixture
+def ops_test(ops_test: OpsTest) -> OpsTest:
+    if os.environ.get("CI") == "true":
+        # Running in GitHub Actions; skip build step
+        # (GitHub Actions uses a separate, cached build step)
+        packed_charms = json.loads(os.environ["CI_PACKED_CHARMS"])
+
+        async def build_charm(charm_path, bases_index: int = None) -> Path:
+            for charm in packed_charms:
+                if Path(charm_path) == Path(charm["directory_path"]):
+                    if bases_index is None or bases_index == charm["bases_index"]:
+                        file_path = Path(charm["file_path"].strip("local:"))
+                        return file_path
+            raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
+
+        ops_test.build_charm = build_charm
+
+    return ops_test
+
 
 def pytest_addoption(parser: Parser):
     parser.addoption(

--- a/tests/integration/helpers/localize_bundle.py
+++ b/tests/integration/helpers/localize_bundle.py
@@ -73,7 +73,7 @@ def localize_bundle_application(
         if not resources:
             resources = get_resources_from_charm_dir(charm_dir)
 
-    bundle["applications"][application]["charm"] = str(charm_file)
+    bundle["applications"][application]["charm"] = f"./{charm_file}"
     bundle["applications"][application]["resources"] = resources
     bundle["applications"][application]["_channel"] = bundle["applications"][application][
         "channel"

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ deps =
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:bundle-integration]
-commands = pytest -vv --tb=native -s {posargs} {[vars]tst_path}/integration
+pass_env =
+    CI
+    CI_PACKED_CHARMS
+commands = pytest -v --tb=native -s {posargs} {[vars]tst_path}/integration
 deps = 
     -r requirements-integration.txt


### PR DESCRIPTION
Use data-platform-workloads' [build_with_cache](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/build_charms_with_cache.yaml) action for speeding up charm builds and reuse charm files across different jobs.