### PR TITLE
feat: Fix KFP API Server K8s Service

### DIFF
--- a/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
+++ b/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ app_name }}
+  name: ml-pipeline
   namespace: '{{ namespace }}'
 spec:
   ports:

--- a/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
+++ b/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
@@ -8,10 +8,10 @@ spec:
   - name: grpc 
     port: {{ grpc-port }}
     protocol: TCP
-    targetPort: 8888
+    targetPort: 8887
   - name: http
     port: {{ http-port }}
     protocol: TCP
-    targetPort: 8887
+    targetPort: 8888
   selector:
     app.kubernetes.io/name: {{ service }}


### PR DESCRIPTION
* Hardcode the name of the Service to `ml-pipeline` to match the value set upstream
  Currently (following the KFP API sidecar rewrite), we submit the Kubernetes Service corresponding to the API Server ourselves when installing the charm. In doing so, we set its name to `kfp-api`. However, this clashes with the value used by default by the KFP client for in-cluster executions.
* Switch the values of the GRPC and HTTP `targetPorts` to match the ones found in the upstream manifests:
  Note that this does not show in our deployments, since the `KubernetesResourcePatcher` immediately patches the service.
  * GRPC: 8887
  * HTTP: 8888