### PR TITLE
[DO NOT MERGE] ci: remove destructive mode

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -133,7 +133,7 @@ jobs:
           # Remove destructive-mode once these bugs are fixed:
           # https://github.com/canonical/charmcraft/issues/554
           # https://github.com/canonical/craft-providers/issues/96
-          tox -e bundle-integration -- --model kubeflow --destructive-mode
+          tox -e bundle-integration -- --model kubeflow
 
       - name: Get all
         run: kubectl get all -A


### PR DESCRIPTION
This PR is opened to confirm that removing `destructive-mode` from the `tox -e bundle-integration -- --model kubeflow` command breaks the CI due to the following:
* https://github.com/canonical/charmcraft/issues/1132
* https://github.com/canonical/charmcraft/issues/1138