### PR TITLE
feat: get images

### DIFF
--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -7,7 +7,7 @@ STATIC_IMAGE_LIST=(
 # from seldon-core
 )
 # dynamic list
-#git checkout origin/track/1.7
+git checkout origin/track/1.7
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+# from seldon-core
+)
+# dynamic list
+#git checkout origin/track/1.7
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -4,7 +4,6 @@
 #
 # static list
 STATIC_IMAGE_LIST=(
-# from seldon-core
 )
 # dynamic list
 git checkout origin/track/1.7

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -6,7 +6,7 @@
 STATIC_IMAGE_LIST=(
 )
 # dynamic list
-git checkout origin/track/1.7
+git checkout origin/track/2.0
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Added script that retrieves image managed by charm(s).