### PR TITLE
build: install setuptools and pip in charms that are missing it

### DIFF
--- a/charms/kfp-schedwf/charmcraft.yaml
+++ b/charms/kfp-schedwf/charmcraft.yaml
@@ -8,3 +8,6 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]  # Fixes install of some packages

--- a/charms/kfp-viewer/charmcraft.yaml
+++ b/charms/kfp-viewer/charmcraft.yaml
@@ -8,3 +8,6 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]  # Fixes install of some packages


### PR DESCRIPTION
Installing these missing python packages so the charm gets the latest version of `pip` and `setuptools`.