### PR TITLE
fix: Handle relation-broken events

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -486,7 +486,15 @@ class KfpApiOperator(CharmBase):
         self._get_db_relation("relational-db")
 
         # retrieve database data from library
-        relation_data = self.database.fetch_relation_data()
+        try:
+            # if called in response to a '*-relation-broken' event, this will raise an exception
+            relation_data = self.database.fetch_relation_data()
+        except KeyError:
+            self.logger.error("Failed to retrieve relation data from library")
+            raise GenericCharmRuntimeError(
+                "Failed to retrieve relational-db data. This is to be expected if executed in"
+                " response to a '*-relation-broken' event"
+            )
         # parse data in relation
         # this also validates expected data by means of KeyError exception
         for val in relation_data.values():

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -174,6 +174,9 @@ class TestCharm:
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
 
+        # remove redundant relation
+        await ops_test.juju("remove-relation", f"{APP_NAME}:mysql", "kfp-db:mysql")
+
     async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
         """Deploy prometheus, grafana and required relations, then test the metrics."""
         prometheus = "prometheus-k8s"
@@ -240,3 +243,8 @@ class TestCharm:
         wait=wait_exponential(multiplier=1, min=1, max=10),
         reraise=True,
     )
+
+    async def test_remove_application(self, ops_test: OpsTest):
+        """Test that the application can be removed successfully."""
+        await ops_test.model.remove_application(app_name=APP_NAME, block_until_done=True)
+        assert APP_NAME not in ops_test.model.applications


### PR DESCRIPTION
In the kfp-api charm, `*-relation-broken` events trigger the same workflow as every other event, forcing the charm to recalculate its configuration. In order to do that, it attempts to retrieve info from its required relations. When executing in response to a relation-broken event for a removed `relational-db` relation, however, the library call to fetch the data raises an error. We need to catch this error and properly propagate it so that the charm lands in the desired state (i.e. Blocked, waiting for the required relation to be added).

Closes #222