### PR TITLE
chore: update copyright year

### DIFF
--- a/charms/kfp-api/pyproject.toml
+++ b/charms/kfp-api/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import json

--- a/charms/kfp-api/tests/unit/__init__.py
+++ b/charms/kfp-api/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Initialize unit tests

--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [flake8]

--- a/charms/kfp-persistence/pyproject.toml
+++ b/charms/kfp-persistence/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the data persistence application of Kubeflow Pipelines.

--- a/charms/kfp-persistence/tests/unit/test_operator.py
+++ b/charms/kfp-persistence/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from contextlib import nullcontext as does_not_raise

--- a/charms/kfp-profile-controller/pyproject.toml
+++ b/charms/kfp-profile-controller/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the Kubeflow Pipelines Profile Controller.

--- a/charms/kfp-profile-controller/tests/integration/profile.yaml
+++ b/charms/kfp-profile-controller/tests/integration/profile.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 apiVersion: kubeflow.org/v1

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import logging

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from base64 import b64decode

--- a/charms/kfp-schedwf/pyproject.toml
+++ b/charms/kfp-schedwf/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the Kubeflow Pipelines Scheduled Workflow Controller.

--- a/charms/kfp-schedwf/tests/unit/test_operator.py
+++ b/charms/kfp-schedwf/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from contextlib import nullcontext as does_not_raise

--- a/charms/kfp-ui/pyproject.toml
+++ b/charms/kfp-ui/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the Kubeflow Pipelines UI.

--- a/charms/kfp-ui/tests/unit/test_operator.py
+++ b/charms/kfp-ui/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from base64 import b64decode

--- a/charms/kfp-viewer/pyproject.toml
+++ b/charms/kfp-viewer/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-viewer/src/charm.py
+++ b/charms/kfp-viewer/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the Kubeflow Pipelines Viewer.

--- a/charms/kfp-viewer/tests/unit/test_operator.py
+++ b/charms/kfp-viewer/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from contextlib import nullcontext as does_not_raise

--- a/charms/kfp-viz/pyproject.toml
+++ b/charms/kfp-viz/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/charms/kfp-viz/src/charm.py
+++ b/charms/kfp-viz/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for the Kubeflow Pipelines Visualization Server.

--- a/charms/kfp-viz/tests/unit/test_operator.py
+++ b/charms/kfp-viz/tests/unit/test_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from contextlib import nullcontext as does_not_raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/tests/integration/helpers/localize_bundle.py
+++ b/tests/integration/helpers/localize_bundle.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import copy
 from pathlib import Path


### PR DESCRIPTION
Update copyright 202* -> 2023

#### Expected CI failures
1. kfp-api individual integration tests will fail due to #243
2. bundle integration tests will fail due to https://github.com/canonical/bundle-kubeflow/issues/648

Merge after #273 