### PR TITLE
fix: add ml-pipeline-service.yaml.j2 in K8S_RESOURCE_FILES (#255)

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -48,6 +48,7 @@ PROBE_PATH = "/apis/v1beta1/healthz"
 
 K8S_RESOURCE_FILES = [
     "src/templates/auth_manifests.yaml.j2",
+    "src/templates/ml-pipeline-service.yaml.j2",
 ]
 MYSQL_WARNING = "Relation mysql is deprecated."
 UNBLOCK_MESSAGE = "Remove deprecated mysql relation to unblock."

--- a/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
+++ b/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
@@ -6,11 +6,11 @@ metadata:
 spec:
   ports:
   - name: grpc 
-    port: {{ grpc-port }}
+    port: {{ grpc_port }}
     protocol: TCP
     targetPort: 8887
   - name: http
-    port: {{ http-port }}
+    port: {{ http_port }}
     protocol: TCP
     targetPort: 8888
   selector:


### PR DESCRIPTION
* fix: add ml-pipeline-service.yaml.j2 in K8S_RESOURCE_FILES

The ml-pipeline Service was omitted when applying k8s resources.

IMPORTANT:
* This is a backport from `main` -> `track/2.0`
* The CI is failing due to canonical/bundle-kubeflow#648, #243, and #250, but #290, #292, and #293 should fix it