### PR TITLE
ci, tests: fix testing in GH runners for kfp-api individual integration tests (#273)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -73,6 +73,19 @@ jobs:
           - kfp-profile-controller
           - kfp-api
     steps:
+      # Ideally we'd use self-hosted runners, but this effort is still not stable
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner, which will liberate around 60 GB of storage
+      # distributed in 40GB for root and around 20 for a mnt point.
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 40960
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
       - uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -39,6 +39,9 @@ class TestCharm:
             trust=True,
         )
 
+        # FIXME: we should probably stop deploying mariadb as:
+        # 1) The team has acceped and started using mysql-k8s more extensively
+        # 2) The repository level integration tests use mysql-k8s only
         await ops_test.model.deploy(
             entity_url="charmed-osm-mariadb-k8s",
             application_name="kfp-db",
@@ -51,24 +54,9 @@ class TestCharm:
         )
         await ops_test.model.deploy(entity_url="kfp-viz", channel="2.0/stable", trust=True)
 
-        # deploy mysql-k8s charm
-        await ops_test.model.deploy(
-            "mysql-k8s",
-            channel="8.0/stable",
-            series="jammy",
-            constraints="mem=250M",
-            trust=True,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=["mysql-k8s"],
-            status="active",
-            raise_on_blocked=True,
-            timeout=60 * 10,
-            idle_period=60,
-        )
-
+        # FIXME: This assertion belongs to unit tests
         # test no database relation, charm should be in blocked state
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+        # assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
 
         await ops_test.model.add_relation(f"{APP_NAME}:mysql", "kfp-db:mysql")
         await ops_test.model.add_relation(f"{APP_NAME}:object-storage", "minio:object-storage")
@@ -79,78 +67,29 @@ class TestCharm:
             status="active",
             raise_on_blocked=False,
             raise_on_error=False,
-            timeout=60 * 10,
-            idle_period=120,
+            timeout=90 * 20,
         )
 
-    async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
-        """Deploy prometheus, grafana and required relations, then test the metrics."""
-        prometheus = "prometheus-k8s"
-        grafana = "grafana-k8s"
-        prometheus_scrape = "prometheus-scrape-config-k8s"
-        scrape_config = {"scrape_interval": "30s"}
-
-        # Deploy and relate prometheus
-        await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
-        await ops_test.model.deploy(grafana, channel="latest/stable", trust=True)
-        await ops_test.model.deploy(
-            prometheus_scrape, channel="latest/stable", config=scrape_config, trust=True
-        )
-
-        await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
-        await ops_test.model.add_relation(
-            f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-        )
-        await ops_test.model.add_relation(
-            f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-        )
-        await ops_test.model.add_relation(
-            f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=["grafana-k8s", "prometheus-k8s", "prometheus-scrape-config-k8s"],
-            status="active",
-            raise_on_blocked=False,
-            raise_on_error=False,
-            timeout=60 * 20,
-            idle_period=60,
-        )
-
-        status = await ops_test.model.get_status()
-        prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
-            "address"
-        ]
-        logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
-
-        for attempt in self.retry_for_5_attempts:
-            logger.info(
-                f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
-            )
-            with attempt:
-                r = requests.get(
-                    f"http://{prometheus_unit_ip}:9090/api/v1/query?"
-                    f'query=up{{juju_application="{APP_NAME}"}}'
-                )
-                response = json.loads(r.content.decode("utf-8"))
-                response_status = response["status"]
-                logger.info(f"Response status is {response_status}")
-                assert response_status == "success"
-
-                response_metric = response["data"]["result"][0]["metric"]
-                assert response_metric["juju_application"] == APP_NAME
-                assert response_metric["juju_model"] == ops_test.model_name
-
-    # Helper to retry calling a function over 30 seconds or 5 attempts
-    retry_for_5_attempts = Retrying(
-        stop=(stop_after_attempt(5) | stop_after_delay(30)),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
-
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_relational_db_relation_with_mysql_relation(self, ops_test: OpsTest):
         """Test failure of addition of relational-db relation with mysql relation present."""
+        # deploy mysql-k8s charm
+        await ops_test.model.deploy(
+            "mysql-k8s",
+            channel="8.0/edge",
+            config={"profile": "testing"},
+            trust=True,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["mysql-k8s"],
+            status="active",
+            raise_on_blocked=True,
+            timeout=90 * 20,
+            idle_period=20,
+        )
 
         # add relational-db relation which should put charm into blocked state,
         # because at this point mysql relation is already established
@@ -170,6 +109,9 @@ class TestCharm:
         # remove just added relational-db relation
         await ops_test.juju("remove-relation", f"{APP_NAME}:relational-db", "mysql-k8s:database")
 
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_relational_db_relation_with_mysql_k8s(self, ops_test: OpsTest):
         """Test no relation and relation with mysql-k8s charm."""
@@ -211,6 +153,9 @@ class TestCharm:
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_msql_relation_with_relational_db_relation(self, ops_test: OpsTest):
         """Test failure of addition of mysql relation with relation-db relation present."""
@@ -228,3 +173,70 @@ class TestCharm:
             timeout=60 * 10,
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+
+    async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
+        """Deploy prometheus, grafana and required relations, then test the metrics."""
+        prometheus = "prometheus-k8s"
+        grafana = "grafana-k8s"
+        prometheus_scrape = "prometheus-scrape-config-k8s"
+        scrape_config = {"scrape_interval": "30s"}
+
+        # Deploy and relate prometheus
+        await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(grafana, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(
+            prometheus_scrape, channel="latest/stable", config=scrape_config, trust=True
+        )
+
+        await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
+        await ops_test.model.add_relation(
+            f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+        )
+
+        # prometheus-k8s needs a significant amount of time to deploy in GH runners,
+        # please make sure the timeout stays above or equal to 90*20
+        await ops_test.model.wait_for_idle(
+            apps=["grafana-k8s", "prometheus-k8s", "prometheus-scrape-config-k8s"],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=90 * 20,
+            idle_period=20,
+        )
+
+        status = await ops_test.model.get_status()
+        prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
+            "address"
+        ]
+        logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
+
+        for attempt in self.retry_for_5_attempts:
+            logger.info(
+                f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
+            )
+            with attempt:
+                r = requests.get(
+                    f"http://{prometheus_unit_ip}:9090/api/v1/query?"
+                    f'query=up{{juju_application="{APP_NAME}"}}'
+                )
+                response = json.loads(r.content.decode("utf-8"))
+                response_status = response["status"]
+                logger.info(f"Response status is {response_status}")
+                assert response_status == "success"
+
+                response_metric = response["data"]["result"][0]["metric"]
+                assert response_metric["juju_application"] == APP_NAME
+                assert response_metric["juju_model"] == ops_test.model_name
+
+    # Helper to retry calling a function over 30 seconds or 5 attempts
+    retry_for_5_attempts = Retrying(
+        stop=(stop_after_attempt(5) | stop_after_delay(30)),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )


### PR DESCRIPTION
* ci: increase GitHub runners storage space for individual integration tests

Increasing the storage space will prevent individual charms to fail by ensuring charms can be deployed in an environment with enough storage space.

* tests: fix kfp-api integration tests in multiple places

The kfp-api individual tests were failing due to a number of reasons, mainly caused by how this charm's dependencies are deployed and the time it takes for those to be up and ready. This commit ensures those dependencies (mysql, minio, prometheus) are active and idle within a reasonable time to avoid timeouts and charms misconfigurations.
1. For mysql-k8s, the charm is now deployed from channel 8.0/edge, a version that contains the testing profile option, which constraints the charm in a recommended way to deploy on GitHub runners.
2. For prometheus-k8s, since this charms requires a significant amount of time to deploy, the wait for idle timeout is increased to 90*20. This change was introduced by canonical/kfp-operators#178, but incorrectly reverted by canonical/kfp-operators#197.

Fixes: #243

IMPORTANT:
* This is a backport from `main` -> `track/2.0`
* The CI is failing due to canonical/bundle-kubeflow#648, but #290 should fix it