### PR TITLE
Merge `KF-4149-dev-branch` into `main`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -95,29 +95,36 @@ jobs:
           juju-channel: 2.9/stable
           charmcraft-channel: latest/candidate
 
-      # TODO: Remove once the actions-operator does this automatically
-      - name: Configure kubectl
-        run: |
-          sg microk8s -c "microk8s config > ~/.kube/config"
-
       - run: |
           sg microk8s -c "tox -e ${{ matrix.charm }}-integration"
 
-      # Collect debug logs if failed
-      - name: Dump Juju/k8s logs on failure
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: ${{ matrix.charm }}
-          model: testing
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        if: always()
 
   test-bundle:
     name: Test the bundle
     runs-on: ubuntu-20.04
 
     steps:
+      # This is a workaround for https://github.com/canonical/kfp-operators/issues/250
+      # Ideally we'd use self-hosted runners, but this effort is still not stable
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner, which will liberate around 60 GB of storage
+      # distributed in 40GB for root and around 20 for a mnt point.
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 40960
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
       - name: Check out code
         uses: actions/checkout@v3
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -125,27 +132,20 @@ jobs:
           channel: 1.24/stable
           juju-channel: 2.9/stable
           charmcraft-channel: latest/candidate
+          microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 
       # TODO: Remove once https://bugs.launchpad.net/juju/+bug/2024897 is fixed
       - name: Refresh Juju snap
         run: |
           sudo snap refresh juju --revision 22345
 
-      # Required until https://github.com/charmed-kubernetes/actions-operator/pull/33 is merged
-      - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
-
-      # TODO: Remove once the actions-operator does this automatically
-      - name: Configure kubectl
-        run: |
-          sg microk8s -c "microk8s config > ~/.kube/config"
-
       - name: Run test
         run: |
           # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
-          # Remove destructive-mode once these bugs are fixed:
-          # https://github.com/canonical/charmcraft/issues/554
-          # https://github.com/canonical/craft-providers/issues/96
+          # Run integration tests against the 1.7 generic install bundle definition
+          # Using destructive mode because of https://github.com/canonical/charmcraft/issues/1132
+          # and https://github.com/canonical/charmcraft/issues/1138
           tox -e bundle-integration -- --model kubeflow --destructive-mode
 
       - name: Get all
@@ -156,10 +156,6 @@ jobs:
         run: juju status
         if: failure()
 
-      - name: Get workload logs
-        run: kubectl logs --tail 100 -nkubeflow -ljuju-app
-        if: failure()
-
-      - name: Get operator logs
-        run: kubectl logs --tail 100 -nkubeflow -ljuju-operator
-        if: failure()
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        if: always()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -73,6 +73,19 @@ jobs:
           - kfp-profile-controller
           - kfp-api
     steps:
+      # Ideally we'd use self-hosted runners, but this effort is still not stable
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner, which will liberate around 60 GB of storage
+      # distributed in 40GB for root and around 20 for a mnt point.
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 40960
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
       - uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/charms/kfp-api/requirements-integration.txt
+++ b/charms/kfp-api/requirements-integration.txt
@@ -119,7 +119,7 @@ jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -235,7 +235,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju
@@ -271,7 +271,7 @@ selenium==4.10.0
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 six==1.16.0
     # via

--- a/charms/kfp-api/requirements-unit.txt
+++ b/charms/kfp-api/requirements-unit.txt
@@ -111,7 +111,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   lightkube
@@ -129,7 +129,7 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r ./requirements.txt
     #   ruamel-yaml
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 sniffio==1.3.0
     # via

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -61,7 +61,7 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops
@@ -72,7 +72,7 @@ ruamel-yaml==0.17.32
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.in
 sniffio==1.3.0
     # via

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -48,6 +48,7 @@ PROBE_PATH = "/apis/v1beta1/healthz"
 
 K8S_RESOURCE_FILES = [
     "src/templates/auth_manifests.yaml.j2",
+    "src/templates/ml-pipeline-service.yaml.j2",
 ]
 MYSQL_WARNING = "Relation mysql is deprecated."
 UNBLOCK_MESSAGE = "Remove deprecated mysql relation to unblock."

--- a/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
+++ b/charms/kfp-api/src/templates/ml-pipeline-service.yaml.j2
@@ -6,11 +6,11 @@ metadata:
 spec:
   ports:
   - name: grpc 
-    port: {{ grpc-port }}
+    port: {{ grpc_port }}
     protocol: TCP
     targetPort: 8887
   - name: http
-    port: {{ http-port }}
+    port: {{ http_port }}
     protocol: TCP
     targetPort: 8888
   selector:

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -39,6 +39,9 @@ class TestCharm:
             trust=True,
         )
 
+        # FIXME: we should probably stop deploying mariadb as:
+        # 1) The team has acceped and started using mysql-k8s more extensively
+        # 2) The repository level integration tests use mysql-k8s only
         await ops_test.model.deploy(
             entity_url="charmed-osm-mariadb-k8s",
             application_name="kfp-db",
@@ -51,24 +54,9 @@ class TestCharm:
         )
         await ops_test.model.deploy(entity_url="kfp-viz", channel="2.0/stable", trust=True)
 
-        # deploy mysql-k8s charm
-        await ops_test.model.deploy(
-            "mysql-k8s",
-            channel="8.0/stable",
-            series="jammy",
-            constraints="mem=250M",
-            trust=True,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=["mysql-k8s"],
-            status="active",
-            raise_on_blocked=True,
-            timeout=60 * 10,
-            idle_period=60,
-        )
-
+        # FIXME: This assertion belongs to unit tests
         # test no database relation, charm should be in blocked state
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+        # assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
 
         await ops_test.model.add_relation(f"{APP_NAME}:mysql", "kfp-db:mysql")
         await ops_test.model.add_relation(f"{APP_NAME}:object-storage", "minio:object-storage")
@@ -79,78 +67,29 @@ class TestCharm:
             status="active",
             raise_on_blocked=False,
             raise_on_error=False,
-            timeout=60 * 10,
-            idle_period=120,
+            timeout=90 * 20,
         )
 
-    async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
-        """Deploy prometheus, grafana and required relations, then test the metrics."""
-        prometheus = "prometheus-k8s"
-        grafana = "grafana-k8s"
-        prometheus_scrape = "prometheus-scrape-config-k8s"
-        scrape_config = {"scrape_interval": "30s"}
-
-        # Deploy and relate prometheus
-        await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
-        await ops_test.model.deploy(grafana, channel="latest/stable", trust=True)
-        await ops_test.model.deploy(
-            prometheus_scrape, channel="latest/stable", config=scrape_config, trust=True
-        )
-
-        await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
-        await ops_test.model.add_relation(
-            f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-        )
-        await ops_test.model.add_relation(
-            f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-        )
-        await ops_test.model.add_relation(
-            f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=["grafana-k8s", "prometheus-k8s", "prometheus-scrape-config-k8s"],
-            status="active",
-            raise_on_blocked=False,
-            raise_on_error=False,
-            timeout=60 * 20,
-            idle_period=60,
-        )
-
-        status = await ops_test.model.get_status()
-        prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
-            "address"
-        ]
-        logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
-
-        for attempt in self.retry_for_5_attempts:
-            logger.info(
-                f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
-            )
-            with attempt:
-                r = requests.get(
-                    f"http://{prometheus_unit_ip}:9090/api/v1/query?"
-                    f'query=up{{juju_application="{APP_NAME}"}}'
-                )
-                response = json.loads(r.content.decode("utf-8"))
-                response_status = response["status"]
-                logger.info(f"Response status is {response_status}")
-                assert response_status == "success"
-
-                response_metric = response["data"]["result"][0]["metric"]
-                assert response_metric["juju_application"] == APP_NAME
-                assert response_metric["juju_model"] == ops_test.model_name
-
-    # Helper to retry calling a function over 30 seconds or 5 attempts
-    retry_for_5_attempts = Retrying(
-        stop=(stop_after_attempt(5) | stop_after_delay(30)),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
-
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_relational_db_relation_with_mysql_relation(self, ops_test: OpsTest):
         """Test failure of addition of relational-db relation with mysql relation present."""
+        # deploy mysql-k8s charm
+        await ops_test.model.deploy(
+            "mysql-k8s",
+            channel="8.0/edge",
+            config={"profile": "testing"},
+            trust=True,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["mysql-k8s"],
+            status="active",
+            raise_on_blocked=True,
+            timeout=90 * 20,
+            idle_period=20,
+        )
 
         # add relational-db relation which should put charm into blocked state,
         # because at this point mysql relation is already established
@@ -170,6 +109,9 @@ class TestCharm:
         # remove just added relational-db relation
         await ops_test.juju("remove-relation", f"{APP_NAME}:relational-db", "mysql-k8s:database")
 
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_relational_db_relation_with_mysql_k8s(self, ops_test: OpsTest):
         """Test no relation and relation with mysql-k8s charm."""
@@ -211,6 +153,9 @@ class TestCharm:
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
+    # FIXME: this test case belongs in unit tests as it is asserting the status of the
+    # unit under a certain condition, we don't actually need the presence of any deployed
+    # charm to test this.
     @pytest.mark.abort_on_fail
     async def test_msql_relation_with_relational_db_relation(self, ops_test: OpsTest):
         """Test failure of addition of mysql relation with relation-db relation present."""
@@ -228,3 +173,70 @@ class TestCharm:
             timeout=60 * 10,
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+
+    async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
+        """Deploy prometheus, grafana and required relations, then test the metrics."""
+        prometheus = "prometheus-k8s"
+        grafana = "grafana-k8s"
+        prometheus_scrape = "prometheus-scrape-config-k8s"
+        scrape_config = {"scrape_interval": "30s"}
+
+        # Deploy and relate prometheus
+        await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(grafana, channel="latest/stable", trust=True)
+        await ops_test.model.deploy(
+            prometheus_scrape, channel="latest/stable", config=scrape_config, trust=True
+        )
+
+        await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
+        await ops_test.model.add_relation(
+            f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+        )
+        await ops_test.model.add_relation(
+            f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+        )
+
+        # prometheus-k8s needs a significant amount of time to deploy in GH runners,
+        # please make sure the timeout stays above or equal to 90*20
+        await ops_test.model.wait_for_idle(
+            apps=["grafana-k8s", "prometheus-k8s", "prometheus-scrape-config-k8s"],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=90 * 20,
+            idle_period=20,
+        )
+
+        status = await ops_test.model.get_status()
+        prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
+            "address"
+        ]
+        logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
+
+        for attempt in self.retry_for_5_attempts:
+            logger.info(
+                f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
+            )
+            with attempt:
+                r = requests.get(
+                    f"http://{prometheus_unit_ip}:9090/api/v1/query?"
+                    f'query=up{{juju_application="{APP_NAME}"}}'
+                )
+                response = json.loads(r.content.decode("utf-8"))
+                response_status = response["status"]
+                logger.info(f"Response status is {response_status}")
+                assert response_status == "success"
+
+                response_metric = response["data"]["result"][0]["metric"]
+                assert response_metric["juju_application"] == APP_NAME
+                assert response_metric["juju_model"] == ops_test.model_name
+
+    # Helper to retry calling a function over 30 seconds or 5 attempts
+    retry_for_5_attempts = Retrying(
+        stop=(stop_after_attempt(5) | stop_after_delay(30)),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )

--- a/charms/kfp-persistence/requirements-integration.txt
+++ b/charms/kfp-persistence/requirements-integration.txt
@@ -89,7 +89,7 @@ jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -190,7 +190,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju
@@ -217,7 +217,7 @@ selenium==4.10.0
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 six==1.16.0
     # via

--- a/charms/kfp-persistence/requirements-unit.txt
+++ b/charms/kfp-persistence/requirements-unit.txt
@@ -61,7 +61,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops
@@ -70,7 +70,7 @@ requests==2.31.0
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 tomli==2.0.1
     # via pytest

--- a/charms/kfp-persistence/requirements.in
+++ b/charms/kfp-persistence/requirements.in
@@ -1,3 +1,3 @@
 ops==1.2.0
 oci-image==1.0.0
-serialized-data-interface<0.7
+serialized-data-interface

--- a/charms/kfp-persistence/requirements.txt
+++ b/charms/kfp-persistence/requirements.txt
@@ -26,13 +26,13 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.in
 urllib3==2.0.3
     # via requests

--- a/charms/kfp-profile-controller/requirements-integration.txt
+++ b/charms/kfp-profile-controller/requirements-integration.txt
@@ -102,7 +102,7 @@ jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -207,7 +207,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju
@@ -235,7 +235,7 @@ selenium==4.10.0
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 six==1.16.0
     # via

--- a/charms/kfp-profile-controller/requirements-unit.txt
+++ b/charms/kfp-profile-controller/requirements-unit.txt
@@ -61,7 +61,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops
@@ -70,7 +70,7 @@ requests==2.31.0
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 tomli==2.0.1
     # via pytest

--- a/charms/kfp-profile-controller/requirements.in
+++ b/charms/kfp-profile-controller/requirements.in
@@ -1,5 +1,5 @@
 ops==1.2.0
 # Unittest fails if not pinned. unknown config option: 'service-port'
 oci-image
-serialized-data-interface<0.7
+serialized-data-interface
 # Unittest fails if not pinned. unknown config option: 'service-port'

--- a/charms/kfp-profile-controller/requirements.txt
+++ b/charms/kfp-profile-controller/requirements.txt
@@ -26,13 +26,13 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.in
 urllib3==2.0.3
     # via requests

--- a/charms/kfp-schedwf/requirements-integration.txt
+++ b/charms/kfp-schedwf/requirements-integration.txt
@@ -75,7 +75,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -166,7 +166,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju

--- a/charms/kfp-schedwf/requirements-unit.txt
+++ b/charms/kfp-schedwf/requirements-unit.txt
@@ -27,7 +27,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops

--- a/charms/kfp-schedwf/requirements.txt
+++ b/charms/kfp-schedwf/requirements.txt
@@ -8,7 +8,7 @@ oci-image==1.0.0
     # via -r ./requirements.in
 ops==2.3.0
     # via -r ./requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via ops
 websocket-client==1.6.0
     # via ops

--- a/charms/kfp-ui/requirements-integration.txt
+++ b/charms/kfp-ui/requirements-integration.txt
@@ -89,7 +89,7 @@ jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -190,7 +190,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju
@@ -217,7 +217,7 @@ selenium==4.10.0
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 six==1.16.0
     # via

--- a/charms/kfp-ui/requirements-unit.txt
+++ b/charms/kfp-ui/requirements-unit.txt
@@ -61,7 +61,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops
@@ -70,7 +70,7 @@ requests==2.31.0
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 tomli==2.0.1
     # via pytest

--- a/charms/kfp-ui/requirements.in
+++ b/charms/kfp-ui/requirements.in
@@ -1,3 +1,3 @@
 ops
 oci-image
-serialized-data-interface<0.7
+serialized-data-interface

--- a/charms/kfp-ui/requirements.txt
+++ b/charms/kfp-ui/requirements.txt
@@ -26,13 +26,13 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.in
 urllib3==2.0.3
     # via requests

--- a/charms/kfp-viewer/requirements-integration.txt
+++ b/charms/kfp-viewer/requirements-integration.txt
@@ -75,7 +75,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -166,7 +166,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju

--- a/charms/kfp-viewer/requirements-unit.txt
+++ b/charms/kfp-viewer/requirements-unit.txt
@@ -27,7 +27,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops

--- a/charms/kfp-viewer/requirements.txt
+++ b/charms/kfp-viewer/requirements.txt
@@ -8,7 +8,7 @@ oci-image==1.0.0
     # via -r ./requirements.in
 ops==2.3.0
     # via -r ./requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via ops
 websocket-client==1.6.0
     # via ops

--- a/charms/kfp-viz/requirements-integration.txt
+++ b/charms/kfp-viz/requirements-integration.txt
@@ -89,7 +89,7 @@ jsonschema==4.17.3
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -190,7 +190,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   juju
@@ -217,7 +217,7 @@ selenium==4.10.0
     #   selenium-wire
 selenium-wire==5.1.0
     # via -r ./requirements-integration.in
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 six==1.16.0
     # via

--- a/charms/kfp-viz/requirements-unit.txt
+++ b/charms/kfp-viz/requirements-unit.txt
@@ -61,7 +61,7 @@ pytest-lazy-fixture==0.6.3
     # via -r ./requirements-unit.in
 pytest-mock==3.11.1
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   ops
@@ -70,7 +70,7 @@ requests==2.31.0
     # via
     #   -r ./requirements.txt
     #   serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.txt
 tomli==2.0.1
     # via pytest

--- a/charms/kfp-viz/requirements.txt
+++ b/charms/kfp-viz/requirements.txt
@@ -26,13 +26,13 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
-serialized-data-interface==0.6.0
+serialized-data-interface==0.7.0
     # via -r ./requirements.in
 urllib3==2.0.3
     # via requests


### PR DESCRIPTION
Merge a collection of chores and fixes from dnplas-dev-fix-ci into main. All commits in this PR have been already reviewed, in their respective PRs.

Changes:
* fix: add ml-pipeline-service.yaml.j2 in K8S_RESOURCE_FILES (https://github.com/canonical/kfp-operators/pull/255) (https://github.com/canonical/kfp-operators/pull/279)
* ci, tests: fix testing in GH runners for kfp-api individual integration tests (https://github.com/canonical/kfp-operators/pull/273)
* build: bump juju 2.9.44.0, sdi->0.7.0, pyyaml->6.0.1 (https://github.com/canonical/kfp-operators/pull/290)
* ci, tests: fix testing in GH runners for kfp-api individual integration tests (https://github.com/canonical/kfp-operators/pull/273) (https://github.com/canonical/kfp-operators/pull/292)
* ci, build: use action to free space from GH runners and update dependencies (https://github.com/canonical/kfp-operators/pull/293)

Part of canonical/bundle-kubeflow#648