### PR TITLE
ci: remove unsed step from integrate workflow

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -160,10 +160,3 @@ jobs:
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         if: always()
-
-      - name: Upload debug artifacts
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: kfp-operators-debug-logs
-          path: ~/kfp-operators-debug-logs


### PR DESCRIPTION
`Upload debug artifacts` was left behind when 7db9c0c was merged.