### PR TITLE
fix: profile-controller integration tests wait_for_idle

### DIFF
--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -58,9 +58,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     )
 
     # Wait for everything to deploy
-    await ops_test.model.wait_for_idle(
-        status="active", raise_on_blocked=False, timeout=60 * 10
-    )
+    await ops_test.model.wait_for_idle(status="active", raise_on_blocked=False, timeout=60 * 10)
 
 
 @pytest.mark.abort_on_fail

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -57,8 +57,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
         trust=True,
     )
 
+    # Wait for everything to deploy
     await ops_test.model.wait_for_idle(
-        apps=[CHARM_NAME], status="active", raise_on_blocked=False, timeout=60 * 10
+        status="active", raise_on_blocked=False, timeout=60 * 10
     )
 
 


### PR DESCRIPTION
The `kfp-profile-controller` integration tests are sometimes failing, due to `wait_for_idle` being set to wait for the `kfp-profile-controller` charm only. This means other charms might not be ready when the `test_build_and_deploy` is done, making this test incorrect, and causing other tests to fail.
Fixed by removing the `apps=[CHARM_NAME]` in `wait_fot_idle`, so it waits for all apps.