### PR TITLE
feat: kfp-viz sidecar rewrite with base charm

### DIFF
--- a/charms/kfp-viz/README.md
+++ b/charms/kfp-viz/README.md
@@ -8,6 +8,6 @@ Visualization (see [CharmHub](https://charmhub.io/?q=kfp-viz)).
 
 To install Kubeflow Pipelines Visualization, run:
 
-    juju deploy kfp-viz
+    juju deploy kfp-viz --trust
 
 For more information, see https://juju.is/docs

--- a/charms/kfp-viz/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/charms/kfp-viz/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -1,0 +1,341 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# KubernetesServicePatch Library.
+
+This library is designed to enable developers to more simply patch the Kubernetes Service created
+by Juju during the deployment of a sidecar charm. When sidecar charms are deployed, Juju creates a
+service named after the application in the namespace (named after the Juju model). This service by
+default contains a "placeholder" port, which is 65536/TCP.
+
+When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
+charm. In this case, any modifications to the default service (created during deployment), will be
+overwritten during a charm upgrade.
+
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+events which applies the patch to the cluster. This should ensure that the service ports are
+correct throughout the charm's life.
+
+The constructor simply takes a reference to the parent charm, and a list of
+[`lightkube`](https://github.com/gtsystem/lightkube) ServicePorts that each define a port for the
+service. For information regarding the `lightkube` `ServicePort` model, please visit the
+`lightkube` [docs](https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#serviceport).
+
+Optionally, a name of the service (in case service name needs to be patched as well), labels,
+selectors, and annotations can be provided as keyword arguments.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.observability_libs.v1.kubernetes_service_patch
+cat << EOF >> requirements.txt
+lightkube
+lightkube-models
+EOF
+```
+
+Then, to initialise the library:
+
+For `ClusterIP` services:
+
+```python
+# ...
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    port = ServicePort(443, name=f"{self.app.name}")
+    self.service_patcher = KubernetesServicePatch(self, [port])
+    # ...
+```
+
+For `LoadBalancer`/`NodePort` services:
+
+```python
+# ...
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    port = ServicePort(443, name=f"{self.app.name}", targetPort=443, nodePort=30666)
+    self.service_patcher = KubernetesServicePatch(
+        self, [port], "LoadBalancer"
+    )
+    # ...
+```
+
+Port protocols can also be specified. Valid protocols are `"TCP"`, `"UDP"`, and `"SCTP"`
+
+```python
+# ...
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    tcp = ServicePort(443, name=f"{self.app.name}-tcp", protocol="TCP")
+    udp = ServicePort(443, name=f"{self.app.name}-udp", protocol="UDP")
+    sctp = ServicePort(443, name=f"{self.app.name}-sctp", protocol="SCTP")
+    self.service_patcher = KubernetesServicePatch(self, [tcp, udp, sctp])
+    # ...
+```
+
+Bound with custom events by providing `refresh_event` argument:
+For example, you would like to have a configurable port in your charm and want to apply
+service patch every time charm config is changed.
+
+```python
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    port = ServicePort(int(self.config["charm-config-port"]), name=f"{self.app.name}")
+    self.service_patcher = KubernetesServicePatch(
+        self,
+        [port],
+        refresh_event=self.on.config_changed
+    )
+    # ...
+```
+
+Additionally, you may wish to use mocks in your charm's unit testing to ensure that the library
+does not try to make any API calls, or open any files during testing that are unlikely to be
+present, and could break your tests. The easiest way to do this is during your test `setUp`:
+
+```python
+# ...
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def setUp(self, *unused):
+    self.harness = Harness(SomeCharm)
+    # ...
+```
+"""
+
+import logging
+from types import MethodType
+from typing import List, Literal, Optional, Union
+
+from lightkube import ApiError, Client
+from lightkube.core import exceptions
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+from lightkube.types import PatchType
+from ops.charm import CharmBase
+from ops.framework import BoundEvent, Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0042f86d0a874435adef581806cddbbb"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 7
+
+ServiceType = Literal["ClusterIP", "LoadBalancer"]
+
+
+class KubernetesServicePatch(Object):
+    """A utility for patching the Kubernetes service set up by Juju."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        ports: List[ServicePort],
+        service_name: Optional[str] = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: Optional[dict] = None,
+        additional_selectors: Optional[dict] = None,
+        additional_annotations: Optional[dict] = None,
+        *,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            ports: a list of ServicePorts
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+            refresh_event: an optional bound event or list of bound events which
+                will be observed to re-apply the patch (e.g. on port change).
+                The `install` and `upgrade-charm` events would be observed regardless.
+        """
+        super().__init__(charm, "kubernetes-service-patch")
+        self.charm = charm
+        self.service_name = service_name if service_name else self._app
+        self.service = self._service_object(
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
+        )
+
+        # Make mypy type checking happy that self._patch is a method
+        assert isinstance(self._patch, MethodType)
+        # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
+        self.framework.observe(charm.on.install, self._patch)
+        self.framework.observe(charm.on.upgrade_charm, self._patch)
+        self.framework.observe(charm.on.update_status, self._patch)
+
+        # apply user defined events
+        if refresh_event:
+            if not isinstance(refresh_event, list):
+                refresh_event = [refresh_event]
+
+            for evt in refresh_event:
+                self.framework.observe(evt, self._patch)
+
+    def _service_object(
+        self,
+        ports: List[ServicePort],
+        service_name: Optional[str] = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: Optional[dict] = None,
+        additional_selectors: Optional[dict] = None,
+        additional_annotations: Optional[dict] = None,
+    ) -> Service:
+        """Creates a valid Service representation.
+
+        Args:
+            ports: a list of ServicePorts
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+
+        Returns:
+            Service: A valid representation of a Kubernetes Service with the correct ports.
+        """
+        if not service_name:
+            service_name = self._app
+        labels = {"app.kubernetes.io/name": self._app}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": self._app}
+        if additional_selectors:
+            selector.update(additional_selectors)
+        return Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace=self._namespace,
+                name=service_name,
+                labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
+            ),
+            spec=ServiceSpec(
+                selector=selector,
+                ports=ports,
+                type=service_type,
+            ),
+        )
+
+    def _patch(self, _) -> None:
+        """Patch the Kubernetes service created by Juju to map the correct port.
+
+        Raises:
+            PatchFailed: if patching fails due to lack of permissions, or otherwise.
+        """
+        try:
+            client = Client()
+        except exceptions.ConfigError as e:
+            logger.warning("Error creating k8s client: %s", e)
+            return
+
+        try:
+            if self._is_patched(client):
+                return
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
+        except ApiError as e:
+            if e.status.code == 403:
+                logger.error("Kubernetes service patch failed: `juju trust` this application.")
+            else:
+                logger.error("Kubernetes service patch failed: %s", str(e))
+        else:
+            logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
+
+    def is_patched(self) -> bool:
+        """Reports if the service patch has been applied.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied.
+        """
+        client = Client()
+        return self._is_patched(client)
+
+    def _is_patched(self, client: Client) -> bool:
+        # Get the relevant service from the cluster
+        try:
+            service = client.get(Service, name=self.service_name, namespace=self._namespace)
+        except ApiError as e:
+            if e.status.code == 404 and self.service_name != self._app:
+                return False
+            logger.error("Kubernetes service get failed: %s", str(e))
+            raise
+
+        # Construct a list of expected ports, should the patch be applied
+        expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
+        # Construct a list in the same manner, using the fetched service
+        fetched_ports = [
+            (p.port, p.targetPort) for p in service.spec.ports  # type: ignore[attr-defined]
+        ]  # noqa: E501
+        return expected_ports == fetched_ports
+
+    @property
+    def _app(self) -> str:
+        """Name of the current Juju application.
+
+        Returns:
+            str: A string containing the name of the current Juju application.
+        """
+        return self.charm.app.name
+
+    @property
+    def _namespace(self) -> str:
+        """The Kubernetes namespace we're running in.
+
+        Returns:
+            str: A string containing the name of the current Kubernetes namespace.
+        """
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
+            return f.read().strip()

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -1,14 +1,15 @@
 name: kfp-viz
 summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK
 description: |
-  Machine learning (ML) toolkit that is dedicated to making deployments
-  of ML workflows on Kubernetes simple, portable, and scalable.
-series: [kubernetes]
-min-juju-version: "2.9.0"
+  The Kubeflow Pipelines visualization service is responsible for generating
+  a visualization from a request provided by the API server.
+containers:
+  ml-pipeline-visualizationserver:
+    resource: oci-image
 resources:
   oci-image:
     type: oci-image
-    description: Backing OCI image
+    description: OCI image for ml-pipeline-visualizationserver
     upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.0-alpha.7
 provides:
   kfp-viz:

--- a/charms/kfp-viz/requirements-unit.in
+++ b/charms/kfp-viz/requirements-unit.in
@@ -14,10 +14,8 @@
 #   * Pinning a version of a python package/lib shared with requirements.in
 #     must not introduce any incompatibilities.
 coverage
-oci-image
 ops
 pytest
 pytest-mock
-pytest-lazy-fixture
 pyyaml
 -r requirements.in

--- a/charms/kfp-viz/requirements-unit.txt
+++ b/charms/kfp-viz/requirements-unit.txt
@@ -23,9 +23,7 @@ iniconfig==2.0.0
 jsonschema==4.17.3
     # via serialized-data-interface
 oci-image==1.0.0
-    # via
-    #   -r requirements-unit.in
-    #   -r requirements.in
+    # via -r requirements.in
 ops==2.5.0
     # via
     #   -r requirements-unit.in
@@ -42,10 +40,7 @@ pyrsistent==0.19.3
 pytest==7.4.0
     # via
     #   -r requirements-unit.in
-    #   pytest-lazy-fixture
     #   pytest-mock
-pytest-lazy-fixture==0.6.3
-    # via -r requirements-unit.in
 pytest-mock==3.11.1
     # via -r requirements-unit.in
 pyyaml==6.0.1

--- a/charms/kfp-viz/requirements-unit.txt
+++ b/charms/kfp-viz/requirements-unit.txt
@@ -4,31 +4,60 @@
 #
 #    pip-compile requirements-unit.in
 #
+anyio==3.7.1
+    # via httpcore
 attrs==23.1.0
     # via jsonschema
 certifi==2023.7.22
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+charmed-kubeflow-chisme==0.2.0
+    # via -r requirements.in
 charset-normalizer==3.2.0
     # via requests
 coverage==7.3.0
     # via -r requirements-unit.in
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
 exceptiongroup==1.1.2
-    # via pytest
+    # via
+    #   anyio
+    #   pytest
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.3
+    # via httpx
+httpx==0.24.1
+    # via lightkube
 idna==3.4
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 importlib-resources==6.0.1
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
+jinja2==3.1.2
+    # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-oci-image==1.0.0
-    # via -r requirements.in
+lightkube==0.14.0
+    # via charmed-kubeflow-chisme
+lightkube-models==1.27.1.4
+    # via lightkube
+markupsafe==2.1.3
+    # via jinja2
 ops==2.5.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
+    #   charmed-kubeflow-chisme
     #   serialized-data-interface
+ordered-set==4.1.0
+    # via deepdiff
 packaging==23.1
     # via pytest
 pkgutil-resolve-name==1.3.10
@@ -46,12 +75,26 @@ pytest-mock==3.11.1
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
+    #   lightkube
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
+ruamel-yaml==0.17.32
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.7
+    # via ruamel-yaml
 serialized-data-interface==0.7.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
+tenacity==8.2.3
+    # via charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
 urllib3==2.0.4

--- a/charms/kfp-viz/requirements.in
+++ b/charms/kfp-viz/requirements.in
@@ -1,3 +1,4 @@
+# Version >=0.2.0 contains the base charm code that's needed.
+charmed-kubeflow-chisme >= 0.2.0
 ops
-oci-image
 serialized-data-interface

--- a/charms/kfp-viz/requirements.txt
+++ b/charms/kfp-viz/requirements.txt
@@ -4,36 +4,79 @@
 #
 #    pip-compile requirements.in
 #
+anyio==3.7.1
+    # via httpcore
 attrs==23.1.0
     # via jsonschema
 certifi==2023.7.22
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+charmed-kubeflow-chisme==0.2.0
+    # via -r requirements.in
 charset-normalizer==3.2.0
     # via requests
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
+exceptiongroup==1.1.3
+    # via anyio
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.3
+    # via httpx
+httpx==0.24.1
+    # via lightkube
 idna==3.4
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 importlib-resources==6.0.1
     # via jsonschema
+jinja2==3.1.2
+    # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-oci-image==1.0.0
-    # via -r requirements.in
+lightkube==0.14.0
+    # via charmed-kubeflow-chisme
+lightkube-models==1.27.1.4
+    # via lightkube
+markupsafe==2.1.3
+    # via jinja2
 ops==2.5.0
     # via
     #   -r requirements.in
+    #   charmed-kubeflow-chisme
     #   serialized-data-interface
+ordered-set==4.1.0
+    # via deepdiff
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0.1
     # via
+    #   lightkube
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via serialized-data-interface
+ruamel-yaml==0.17.32
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.7
+    # via ruamel-yaml
 serialized-data-interface==0.7.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
+tenacity==8.2.3
+    # via charmed-kubeflow-chisme
 urllib3==2.0.4
     # via requests
 websocket-client==1.6.1

--- a/charms/kfp-viz/src/charm.py
+++ b/charms/kfp-viz/src/charm.py
@@ -9,18 +9,19 @@ https://github.com/canonical/kfp-operators
 
 import logging
 
-from oci_image import OCIImageResource, OCIImageResourceError
+from charmed_kubeflow_chisme.components import (
+    CharmReconciler,
+    LeadershipGateComponent,
+    SdiRelationBroadcasterComponent,
+)
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
-from serialized_data_interface.errors import (
-    NoCompatibleVersions,
-    NoVersionsListed,
-    RelationDataError,
-)
-from serialized_data_interface.sdi import get_interfaces
 
-log = logging.getLogger()
+from components.pebble_components import KfpVizPebbleService
+
+logger = logging.getLogger()
 
 
 class KfpVizOperator(CharmBase):
@@ -32,119 +33,48 @@ class KfpVizOperator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.log = logging.getLogger()
-        self.image = OCIImageResource(self, "oci-image")
+        http_port = ServicePort(int(self.model.config["http-port"]), name="http")
+        self.service_patcher = KubernetesServicePatch(
+            self, [http_port], service_name=f"{self.model.app.name}"
+        )
 
-        self.framework.observe(self.on.install, self._main)
-        self.framework.observe(self.on.upgrade_charm, self._main)
-        self.framework.observe(self.on.config_changed, self._main)
-        self.framework.observe(self.on.leader_elected, self._main)
-        self.framework.observe(self.on["kfp-viz"].relation_changed, self._main)
+        # Charm logic
+        self.charm_reconciler = CharmReconciler(self)
 
-    def _send_viz_info(self, interfaces):
-        if interfaces["kfp-viz"]:
-            interfaces["kfp-viz"].send_data(
-                {
+        self.leadership_gate = self.charm_reconciler.add(
+            component=LeadershipGateComponent(
+                charm=self,
+                name="leadership-gate",
+            ),
+            depends_on=[],
+        )
+
+        self.kfp_viz_relation = self.charm_reconciler.add(
+            SdiRelationBroadcasterComponent(
+                charm=self,
+                name="relation:kfp-viz",
+                relation_name="kfp-viz",
+                data_to_send={
                     "service-name": f"{self.model.app.name}.{self.model.name}",
                     "service-port": self.model.config["http-port"],
-                }
-            )
-
-    def _main(self, event):
-        # Set up all relations/fetch required data
-        try:
-            self._check_leader()
-            interfaces = self._get_interfaces()
-            image_details = self.image.fetch()
-        except (CheckFailedError, OCIImageResourceError) as check_failed:
-            self.model.unit.status = check_failed.status
-            self.log.info(str(check_failed.status))
-            return
-
-        self._send_viz_info(interfaces)
-
-        port = self.model.config["http-port"]
-        self.model.unit.status = MaintenanceStatus("Setting pod spec")
-        self.model.pod.set_spec(
-            {
-                "version": 3,
-                "containers": [
-                    {
-                        "name": "ml-pipeline-visualizationserver",
-                        "imageDetails": image_details,
-                        "ports": [
-                            {
-                                "name": "http",
-                                "containerPort": int(port),
-                            },
-                        ],
-                        "kubernetes": {
-                            "readinessProbe": {
-                                "exec": {
-                                    "command": [
-                                        "wget",
-                                        "-q",
-                                        "-S",
-                                        "-O",
-                                        "-",
-                                        f"http://localhost:{port}/",
-                                    ]
-                                },
-                                "initialDelaySeconds": 3,
-                                "periodSeconds": 5,
-                                "timeoutSeconds": 2,
-                            },
-                            "livenessProbe": {
-                                "exec": {
-                                    "command": [
-                                        "wget",
-                                        "-q",
-                                        "-S",
-                                        "-O",
-                                        "-",
-                                        f"http://localhost:{port}/",
-                                    ]
-                                },
-                                "initialDelaySeconds": 3,
-                                "periodSeconds": 5,
-                                "timeoutSeconds": 2,
-                            },
-                        },
-                    }
-                ],
-            },
+                },
+            ),
+            depends_on=[self.leadership_gate],
         )
-        self.model.unit.status = ActiveStatus()
 
-    def _check_leader(self):
-        if not self.unit.is_leader():
-            # We can't do anything useful when not the leader, so do nothing.
-            raise CheckFailedError("Waiting for leadership", WaitingStatus)
+        # The service_name should be consistent with the rock predefined
+        # service name to be able to re-use it, do not change it unless
+        # it changes in the corresponding Rockcraft project.
+        self.ml_pipeline_visualizationserver_container = self.charm_reconciler.add(
+            component=KfpVizPebbleService(
+                charm=self,
+                name="kfp-viz-pebble-service",
+                container_name="ml-pipeline-visualizationserver",
+                service_name="vis-server",
+            )
+        )
 
-    def _get_interfaces(self):
-        # Remove this abstraction when SDI adds .status attribute to NoVersionsListed,
-        # NoCompatibleVersionsListed:
-        # https://github.com/canonical/serialized-data-interface/issues/26
-        try:
-            interfaces = get_interfaces(self)
-        except NoVersionsListed as err:
-            raise CheckFailedError(str(err), WaitingStatus)
-        except NoCompatibleVersions as err:
-            raise CheckFailedError(str(err), BlockedStatus)
-        except RelationDataError as err:
-            raise CheckFailedError(str(err), BlockedStatus)
-        return interfaces
-
-
-class CheckFailedError(Exception):
-    """Raise this exception if one of the checks in main fails."""
-
-    def __init__(self, msg, status_type=None):
-        super().__init__()
-
-        self.msg = msg
-        self.status_type = status_type
-        self.status = status_type(msg)
+        self.charm_reconciler.install_default_event_handlers()
 
 
 if __name__ == "__main__":

--- a/charms/kfp-viz/src/components/pebble_components.py
+++ b/charms/kfp-viz/src/components/pebble_components.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from charmed_kubeflow_chisme.components.pebble_component import PebbleServiceComponent
+from ops.pebble import Layer
+
+logger = logging.getLogger(__name__)
+
+
+class KfpVizPebbleService(PebbleServiceComponent):
+    def get_layer(self) -> Layer:
+        """Pebble configuration layer for ml-pipeline-visualizationserver."""
+        layer = Layer(
+            {
+                "services": {
+                    self.service_name: {
+                        "override": "replace",
+                        "summary": "entry point for ml-pipeline-visualizationserver",
+                        "command": "python3.6 server.py",  # Must be a string
+                        "startup": "enabled",
+                        "on-check-failure": {"kfp-viz-up": "restart"},
+                    }
+                },
+                "checks": {
+                    "kfp-viz-up": {
+                        "override": "replace",
+                        "period": "5m",
+                        "timeout": "60s",
+                        "threshold": 3,
+                        "http": {
+                            "url": f"http://localhost:{self._charm.model.config['http-port']}"
+                        },
+                    }
+                },
+            }
+        )
+
+        return layer

--- a/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
@@ -73,6 +73,7 @@ applications:
     charm: kfp-viz
     channel: 2.0/stable
     scale: 1
+    trust: true
 {% else %}
   kfp-api:
     charm: {{ kfp_api }}
@@ -103,6 +104,7 @@ applications:
     charm: {{ kfp_viz }}
     resources: {{ kfp_viz_resources }}
     scale: 1
+    trust: true
 {%- endif %}
 relations:
 - - kfp-api:kfp-api

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -12,7 +12,7 @@ applications:
   kfp-schedwf:             { charm: ch:kfp-schedwf, channel: latest/edge, scale: 1, trust: true}
   kfp-ui:                  { charm: ch:kfp-ui, channel: latest/edge, trust: true,            scale: 1 }
   kfp-viewer:              { charm: ch:kfp-viewer, channel: latest/edge, trust: true         scale: 1 }
-  kfp-viz:                 { charm: ch:kfp-viz, channel: latest/edge,                        scale: 1 }
+  kfp-viz:                 { charm: ch:kfp-viz, channel: latest/edge, trust: true         scale: 1 }
 {%- else %}
   kfp-api:
     charm: {{ kfp_api }}
@@ -47,6 +47,7 @@ applications:
     charm: {{ kfp_viz }}
     resources: {{ kfp_viz_resources }}
     scale: 1
+    trust: true
 {%- endif %}
 relations:
 - [argo-controller:object-storage, minio:object-storage]


### PR DESCRIPTION
based on #305 due to unverified commits

Rewrite the `kfp-viz` charm, migrating it from podspec to sidecar using the reusable base charm in charmed-kubeflow-chisme. More details on the base charm [in this README.md](https://github.com/canonical/charmed-kubeflow-chisme/tree/main/src/charmed_kubeflow_chisme/components#readme)
# Summary of changes
- rewrites all charm logic in terms of Components
- implements the Pebble container
- implements the relation handler
- refactors the unit tests to use the base charm tooling
- modifies requirements.in and requirements-unit.in and updates the requirements-*.txt's

**NOTE:** Due to deployment parameter in PodSpec version, kfp-persistence cannot be upgraded using Juju refresh:
juju.errors.JujuAPIError: Juju on containers does not support updating deployment info for services.
Upgrade will be done by re-deploying the charm.