### PR TITLE
feat: get images on main

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -2,13 +2,7 @@
 #
 # This script returns list of container images that are managed by this charm and/or its workload
 #
-# static list
-STATIC_IMAGE_LIST=(
-)
 # dynamic list
-git checkout origin/track/2.0
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
-
-printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
For details refer to: https://github.com/canonical/bundle-kubeflow/issues/679

Summary of changes:
- Added script that produces list of container images managed by charm in this repository. Image list is a dynamic list.

NOTE: Script replaced outdated get-images-1.7-stable.sh script.