### PR TITLE
fix: Bump libjuju to 2.9.44.1

### DIFF
--- a/charms/kfp-api/requirements-integration.txt
+++ b/charms/kfp-api/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-persistence/requirements-integration.txt
+++ b/charms/kfp-persistence/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-profile-controller/requirements-integration.txt
+++ b/charms/kfp-profile-controller/requirements-integration.txt
@@ -86,7 +86,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-schedwf/requirements-integration.txt
+++ b/charms/kfp-schedwf/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-ui/requirements-integration.txt
+++ b/charms/kfp-ui/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-viewer/requirements-integration.txt
+++ b/charms/kfp-viewer/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/charms/kfp-viz/requirements-integration.txt
+++ b/charms/kfp-viz/requirements-integration.txt
@@ -73,7 +73,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -130,7 +130,7 @@ jsonschema==4.17.3
     # via
     #   -r requirements-integration.in
     #   kfp
-juju==2.9.44.0
+juju==2.9.44.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator


### PR DESCRIPTION
Upgrade python-libjuju to 2.9.44.1 which fixes issues in our integration tests that deploy `mysql-k8s` from `8.0/edge`.

Closes https://github.com/canonical/kfp-operators/issues/316