### PR TITLE
fix: Add Persistence Agent ClusterRole and Binding

### DIFF
--- a/charms/kfp-persistence/requirements-unit.txt
+++ b/charms/kfp-persistence/requirements-unit.txt
@@ -45,7 +45,9 @@ jinja2==3.1.2
 jsonschema==4.17.3
     # via serialized-data-interface
 lightkube==0.14.0
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
 lightkube-models==1.27.1.4
     # via lightkube
 markupsafe==2.1.3

--- a/charms/kfp-persistence/requirements.in
+++ b/charms/kfp-persistence/requirements.in
@@ -1,3 +1,4 @@
 charmed-kubeflow-chisme
+lightkube
 ops
 serialized-data-interface

--- a/charms/kfp-persistence/requirements.txt
+++ b/charms/kfp-persistence/requirements.txt
@@ -39,7 +39,9 @@ jinja2==3.1.2
 jsonschema==4.17.3
     # via serialized-data-interface
 lightkube==0.14.0
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
 lightkube-models==1.27.1.4
     # via lightkube
 markupsafe==2.1.3

--- a/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
@@ -1,0 +1,58 @@
+# Source manifests/apps/pipeline/upstream/base/installs/multi-user/persistence-agent/
+# These manifest files have been modified to suit the needs of the charm; the app label, metadata name,
+# and namespace fields will be rendered with information from the application and the model.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ app_name }}
+  name: {{ app_name }}-role
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ app_name }}-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ app_name }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ app_name }}-sa
+  namespace: {{ namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ app_name }}-sa
+  namespace: {{ namespace }}

--- a/charms/kfp-persistence/tests/unit/test_operator.py
+++ b/charms/kfp-persistence/tests/unit/test_operator.py
@@ -21,7 +21,7 @@ def harness():
     return harness
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def mocked_lightkube_client(mocker):
     """Mocks the Lightkube Client in charm.py, returning a mock instead."""
     mocked_lightkube_client = MagicMock()

--- a/charms/kfp-persistence/tests/unit/test_operator.py
+++ b/charms/kfp-persistence/tests/unit/test_operator.py
@@ -21,7 +21,7 @@ def harness():
     return harness
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def mocked_lightkube_client(mocker):
     """Mocks the Lightkube Client in charm.py, returning a mock instead."""
     mocked_lightkube_client = MagicMock()

--- a/charms/kfp-persistence/tests/unit/test_operator.py
+++ b/charms/kfp-persistence/tests/unit/test_operator.py
@@ -21,9 +21,15 @@ def harness():
     return harness
 
 
-def test_not_leader(
-    harness,  # noqa F811
-):
+@pytest.fixture()
+def mocked_lightkube_client(mocker):
+    """Mocks the Lightkube Client in charm.py, returning a mock instead."""
+    mocked_lightkube_client = MagicMock()
+    mocker.patch("charm.lightkube.Client", return_value=mocked_lightkube_client)
+    yield mocked_lightkube_client
+
+
+def test_not_leader(harness, mocked_lightkube_client):
     """Test not a leader scenario."""
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == WaitingStatus(
@@ -35,7 +41,7 @@ RELATION_NAME = "kfp-api"
 OTHER_APP_NAME = "kfp-api-provider"
 
 
-def test_kfp_api_relation_with_data(harness):
+def test_kfp_api_relation_with_data(harness, mocked_lightkube_client):
     """Test that if Leadership is Active, the kfp-api relation operates as expected."""
     # Arrange
     harness.begin()
@@ -51,7 +57,7 @@ def test_kfp_api_relation_with_data(harness):
     assert isinstance(harness.charm.kfp_api_relation.status, ActiveStatus)
 
 
-def test_kfp_api_relation_without_data(harness):
+def test_kfp_api_relation_without_data(harness, mocked_lightkube_client):
     """Test that the kfp-api relation goes Blocked if no data is available."""
     # Arrange
     harness.begin()
@@ -67,7 +73,7 @@ def test_kfp_api_relation_without_data(harness):
     assert isinstance(harness.charm.kfp_api_relation.status, BlockedStatus)
 
 
-def test_kfp_api_relation_without_relation(harness):
+def test_kfp_api_relation_without_relation(harness, mocked_lightkube_client):
     """Test that the kfp-api relation goes Blocked if no relation is established."""
     # Arrange
     harness.begin()
@@ -83,7 +89,7 @@ def test_kfp_api_relation_without_relation(harness):
     assert isinstance(harness.charm.kfp_api_relation.status, BlockedStatus)
 
 
-def test_pebble_services_running(harness):
+def test_pebble_services_running(harness, mocked_lightkube_client):
     """Test that if the Kubernetes Component is Active, the pebble services successfully start."""
     # Arrange
     harness.begin()


### PR DESCRIPTION
Apply auth manifests (KF 1.8) for the KFP Persistence Agent, including the ClusterRole, ClusterRoleBinding, and ServiceAccount that allow the workload to get, list, and watch workflows/scheduledworkflows, as well as get namespaces.