### PR TITLE
fix: Unset namespace in persistence agent config

### DIFF
--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -65,7 +65,6 @@ class KfpPersistenceOperator(CharmBase):
                     KFP_API_SERVICE_NAME=self.kfp_api_relation.component.get_data()[
                         "service-name"
                     ],
-                    NAMESPACE=str(self.model.name),
                 ),
             ),
             depends_on=[self.leadership_gate, self.kfp_api_relation],

--- a/charms/kfp-persistence/src/components/pebble_components.py
+++ b/charms/kfp-persistence/src/components/pebble_components.py
@@ -14,7 +14,6 @@ class PesistenceAgentServiceConfig:
     """Defines configuration for PersistenceAgent Service."""
 
     KFP_API_SERVICE_NAME: str
-    NAMESPACE: str
 
 
 class PersistenceAgentPebbleService(PebbleServiceComponent):
@@ -43,7 +42,7 @@ class PersistenceAgentPebbleService(PebbleServiceComponent):
         except Exception as err:
             raise ValueError(f"{self.name}: configuration is not provided") from err
 
-        if len(service_config.KFP_API_SERVICE_NAME) == 0 or len(service_config.NAMESPACE) == 0:
+        if len(service_config.KFP_API_SERVICE_NAME) == 0:
             logger.info(f"{self.name}: configuration is not valid")
             return None
 
@@ -51,7 +50,7 @@ class PersistenceAgentPebbleService(PebbleServiceComponent):
         command = (
             "persistence_agent",
             "--logtostderr=true",
-            f"--namespace={service_config.NAMESPACE}",
+            "--namespace=",
             "--ttlSecondsAfterWorkflowFinish=86400",
             "--numWorker=2",
             f"--mlPipelineAPIServerName={service_config.KFP_API_SERVICE_NAME}",
@@ -88,7 +87,7 @@ class PersistenceAgentPebbleService(PebbleServiceComponent):
             return WaitingStatus(f"Configuration is not provided: {err}")
 
         # validate values
-        if len(service_config.KFP_API_SERVICE_NAME) == 0 or len(service_config.NAMESPACE) == 0:
+        if len(service_config.KFP_API_SERVICE_NAME) == 0:
             return WaitingStatus("Configuration is not valid")
 
         return super().get_status()


### PR DESCRIPTION
Currently, we provide the --namespace option when starting the persistence agent, setting its value to match that of the model where the charm is deployed. However, this won't work for multi-user Kubeflow installations, where the namespace value should be empty as per the corresponding upstream [manifests](https://github.com/kubeflow/manifests/blob/92542398b2efbbfd9498e40a7cef6e94c68430bf/apps/pipeline/upstream/base/installs/multi-user/persistence-agent/deployment-patch.yaml#L14-L15).

Closes https://github.com/canonical/kfp-operators/issues/323