### PR TITLE
scripts(get-images): Include cache-image config

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -5,4 +5,5 @@
 # dynamic list
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options.cache-image |  select(.) | .default' {} \;))
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Modify `get-images.sh` script in order to include cache-image from config.yaml file.
Refs #335 