### PR TITLE
port(script get-images): Include cache-image config (#336)

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -5,4 +5,5 @@
 # dynamic list
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options.cache-image |  select(.) | .default' {} \;))
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
This PR backports #336 to `main` branch. 