### PR TITLE
backport(fix): Handle relation-broken events (#272)

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -483,7 +483,15 @@ class KfpApiOperator(CharmBase):
         self._get_db_relation("relational-db")
 
         # retrieve database data from library
-        relation_data = self.database.fetch_relation_data()
+        try:
+            # if called in response to a '*-relation-broken' event, this will raise an exception
+            relation_data = self.database.fetch_relation_data()
+        except KeyError:
+            self.logger.error("Failed to retrieve relation data from library")
+            raise GenericCharmRuntimeError(
+                "Failed to retrieve relational-db data. This is to be expected if executed in"
+                " response to a '*-relation-broken' event"
+            )
         # parse data in relation
         # this also validates expected data by means of KeyError exception
         for val in relation_data.values():

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -174,6 +174,9 @@ class TestCharm:
         )
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
 
+        # remove redundant relation
+        await ops_test.juju("remove-relation", f"{APP_NAME}:mysql", "kfp-db:mysql")
+
     async def test_prometheus_grafana_integration(self, ops_test: OpsTest):
         """Deploy prometheus, grafana and required relations, then test the metrics."""
         prometheus = "prometheus-k8s"
@@ -240,3 +243,8 @@ class TestCharm:
         wait=wait_exponential(multiplier=1, min=1, max=10),
         reraise=True,
     )
+
+    async def test_remove_application(self, ops_test: OpsTest):
+        """Test that the application can be removed successfully."""
+        await ops_test.model.remove_application(app_name=APP_NAME, block_until_done=True)
+        assert APP_NAME not in ops_test.model.applications

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import ErrorWithStatus, KfpApiOperator
@@ -570,3 +570,39 @@ class TestCharm:
                 "db_host": "host",
                 "db_port": "1234",
             }
+
+    def test_relational_db_relation_broken(
+        self,
+        mocked_resource_handler,
+        mocked_lightkube_client,
+        mocked_kubernetes_service_patcher,
+        harness: Harness,
+    ):
+        """Test that a relation broken event is properly handled."""
+        database = MagicMock()
+        fetch_relation_data = MagicMock(side_effect=KeyError())
+        database.fetch_relation_data = fetch_relation_data
+        harness.model.get_relation = MagicMock(
+            side_effect=self._get_relation_db_only_side_effect_func
+        )
+
+        rel_name = "relational-db"
+        rel_id = harness.add_relation(rel_name, "relational-db-provider")
+
+        harness.begin()
+        harness.set_leader(True)
+        harness.container_pebble_ready(KFP_API_CONTAINER_NAME)
+
+        assert harness.model.unit.status == WaitingStatus("Waiting for relational-db data")
+
+        harness.charm.database = database
+        del harness.model.get_relation
+
+        harness._emit_relation_broken(rel_name, rel_id, "kfp-api")
+
+        assert harness.model.unit.status == BlockedStatus(
+            "Please add required database relation: eg. relational-db"
+        )
+
+        harness.charm.on.remove.emit()
+        assert harness.model.unit.status == MaintenanceStatus("K8S resources removed")

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -11,6 +11,8 @@ from ops.testing import Harness
 
 from charm import ErrorWithStatus, KfpApiOperator
 
+KFP_API_CONTAINER_NAME = "apiserver"
+
 
 @pytest.fixture()
 def mocked_resource_handler(mocker):


### PR DESCRIPTION
* api: Handle relation-broken events

In the kpf-api charm, '*-relation-broken' events trigger the same workflow as every other event, forcing the charm to recalculate its configuration. In order to do that, it attempts to retrieve info from its required relations. When executing in response to a relation-broken event for a removed relational-db relation, however, the library call to fetch the data raises an error. We need to catch this error and properly propagate it so that the charm lands in the desired state (i.e. Blocked, waiting for the required relation to be added).

Closes #222