### PR TITLE
Decorator controller rewrite

### DIFF
--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -35,8 +35,8 @@ from components.pebble_components import (
 
 logger = logging.getLogger(__name__)
 
-CompositeController = create_global_resource(
-    "metacontroller.k8s.io", "v1alpha1", "CompositeController", "compositecontrollers"
+DecoratorController = create_global_resource(
+    "metacontroller.k8s.io", "v1alpha1", "DecoratorController", "decoratorcontrollers"
 )
 CONTROLLER_PORT = 80
 DISABLE_ISTIO_SIDECAR = "false"
@@ -48,6 +48,7 @@ KFP_DEFAULT_PIPELINE_ROOT = ""
 KFP_IMAGES_VERSION = "2.0.0-alpha.7"
 METADATA_GRPC_SERVICE_HOST = "mlmd.kubeflow"
 METADATA_GRPC_SERVICE_PORT = "8080"
+NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
 SYNC_CODE_DESTINATION_PATH = "/hooks/sync.py"
 
@@ -91,7 +92,7 @@ class KfpProfileControllerOperator(CharmBase):
                 charm=self,
                 name="kubernetes:secrets-and-compositecontroller",
                 resource_templates=K8S_RESOURCE_FILES,
-                krh_resource_types={Secret, CompositeController},
+                krh_resource_types={Secret, DecoratorController},
                 krh_labels=create_charm_default_labels(
                     self.app.name,
                     self.model.name,
@@ -111,6 +112,7 @@ class KfpProfileControllerOperator(CharmBase):
                         )
                     ).decode("utf-8"),
                     "minio_secret_name": f"{self.model.app.name}-minio-credentials",
+                    "label": NAMESPACE_LABEL,
                 },
                 lightkube_client=lightkube.Client(),
             ),

--- a/charms/kfp-profile-controller/src/templates/crd_manifests.yaml.j2
+++ b/charms/kfp-profile-controller/src/templates/crd_manifests.yaml.j2
@@ -1,9 +1,9 @@
 apiVersion: metacontroller.k8s.io/v1alpha1
-kind: CompositeController
+kind: DecoratorController
 metadata:
   name: kubeflow-pipelines-profile-controller
 spec:
-  childResources:
+  attachments:
   - apiVersion: v1
     resource: secrets
     updateStrategy:
@@ -24,12 +24,14 @@ spec:
     resource: poddefaults
     updateStrategy:
       method: InPlace
-  generateSelector: true
   hooks:
     sync:
       webhook:
         url: {{ sync_webhook_url }}
-  parentResource:
-    apiVersion: v1
+  resources:
+  - apiVersion: v1
     resource: namespaces
+    labelSelector:
+      matchExpressions:
+      - {key: {{ label }}, operator: Exists}
   resyncPeriodSeconds: 3600

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -47,6 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         entity_url="metacontroller-operator",
         # TODO: Revert once metacontroller stable supports k8s 1.22
         channel="latest/edge",
+        # Remove this config option after the metacontroller-operator is updated to v3
         config={"metacontroller-image": "docker.io/metacontrollerio/metacontroller:v3.0.0"},
         trust=True,
     )

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -47,6 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         entity_url="metacontroller-operator",
         # TODO: Revert once metacontroller stable supports k8s 1.22
         channel="latest/edge",
+        config={"metacontroller-image": "docker.io/metacontrollerio/metacontroller:v3.0.0"},
         trust=True,
     )
 


### PR DESCRIPTION
https://github.com/canonical/kfp-operators/issues/334

Changes: 
- use Decorator controller instead of Composite controller.
- use metacontroller v3.0.0 (as it supports Decorator controller).

Tests:
- integration tests are checking also scenario where minio credentials are changed. 

This PR resolves [resource-dispatcher's issue ](https://github.com/canonical/resource-dispatcher/issues/30) as we can migrate to metacontroller v3