### PR TITLE
fix: explicitly set the command for schedwf pebble Layer

### DIFF
--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -68,6 +68,7 @@ class KfpSchedwf(CharmBase):
                 container_name="ml-pipeline-scheduledworkflow",
                 service_name="controller",
                 timezone=self.model.config["timezone"],
+                namespace=self.model.name,
             ),
             depends_on=[self.kubernetes_resources],
         )

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -13,11 +13,13 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self,
         *args,
         timezone: str,
+        namespace: str,
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
         super().__init__(*args, **kwargs)
         self.environment = {"CRON_SCHEDULE_TIMEZONE": timezone}
+        self.namespace = namespace
 
     def get_layer(self) -> Layer:
         """Defines and returns Pebble layer configuration
@@ -36,8 +38,10 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                 "description": "Pebble config layer for kfp-schedwf",
                 "services": {
                     self.service_name: {
-                        "override": "merge",
+                        "override": "replace",
+                        "summary": "scheduled workflow controller service",
                         "startup": "enabled",
+                        "command": f"/bin/controller --logtostderr=true --namespace={self.namespace}",
                         "environment": self.environment,
                     }
                 },

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -41,7 +41,8 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         "override": "replace",
                         "summary": "scheduled workflow controller service",
                         "startup": "enabled",
-                        "command": f"/bin/controller --logtostderr=true --namespace={self.namespace}",
+                        "command": "/bin/controller --logtostderr=true"
+                        " --namespace={self.namespace}",
                         "environment": self.environment,
                     }
                 },


### PR DESCRIPTION
This commit explicitly sets the `command` field in the pebble Layer instead of relying on the rock to configure the service.