### PR TITLE
ci: run bundle integration tests w/o destruction mode 

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -94,7 +94,7 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: latest/edge
 
       - run: |
           sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration"
@@ -132,7 +132,7 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: latest/edge
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 
       - name: Run test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -140,9 +140,7 @@ jobs:
           # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
           # Run integration tests against the 1.7 generic install bundle definition
-          # Using destructive mode because of https://github.com/canonical/charmcraft/issues/1132
-          # and https://github.com/canonical/charmcraft/issues/1138
-          sg snap_microk8s -c "tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/kfp_1.7_stable_install.yaml.j2 --destructive-mode"
+          sg snap_microk8s -c "tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/kfp_1.7_stable_install.yaml.j2"
 
       - name: Get all
         run: kubectl get all -A


### PR DESCRIPTION
As https://github.com/canonical/charmcraft/issues/1132 and https://github.com/canonical/charmcraft/issues/1138 got fixed, destructive mode can now be removed from the tox command when running integration tests. The fix is in latest/edge, this PR also points to that version.