### PR TITLE
fix: add correct SA name to CRB

### DIFF
--- a/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
@@ -48,7 +48,7 @@ roleRef:
   name: {{ app_name }}-role
 subjects:
 - kind: ServiceAccount
-  name: {{ app_name }}-sa
+  name: {{ sa_name }}
   namespace: {{ namespace }}
 ---
 apiVersion: v1


### PR DESCRIPTION
The previous CRB was pointing to a SA that is not used by the api server for authentication. The rename was introduced by a244ffe.