### PR TITLE
fix: apply authorization policy to fix istio traffic issues

### DIFF
--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -453,7 +453,7 @@ def server_factory(visualization_server_image,
                         }
                     }
                 },
-                # This AuthorizationPolicy was added from [TODO: link PR]
+                # This AuthorizationPolicy was added from https://github.com/canonical/kfp-operators/pull/356
                 # to fix https://github.com/canonical/notebook-operators/issues/311
                 # and https://github.com/canonical/kfp-operators/issues/355.
                 # Remove when istio sidecars are implemented.

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -453,6 +453,29 @@ def server_factory(visualization_server_image,
                         }
                     }
                 },
+                # This AuthorizationPolicy was added from [TODO: link PR]
+                # to fix https://github.com/canonical/notebook-operators/issues/311
+                # and https://github.com/canonical/kfp-operators/issues/355.
+                # Remove when istio sidecars are implemented.
+                {
+                    "apiVersion": "security.istio.io/v1beta1",
+                    "kind": "AuthorizationPolicy",
+                    "metadata": {"name": "ns-owner-access-istio-charmed", "namespace": namespace},
+                    "spec": {
+                        "rules": [
+                            {
+                                "when": [
+                                    {"key": "request.headers[kubeflow-userid]", "values": ["*"]}
+                                ]
+                            },
+                            {
+                                "to": [
+                                    {"operation": {"methods": ["GET"], "paths": ["*/api/kernels"]}}
+                                ]
+                            },
+                        ]
+                    },
+                },
             ]
             print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
             print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))


### PR DESCRIPTION
closes https://github.com/canonical/notebook-operators/issues/311 and https://github.com/canonical/kfp-operators/issues/355

## Testing
1. deploy charmed kubeflow latest/edge
2. refresh the `kfp-profile-controller` charm to the one from this PR
  ```
  juju refresh kfp-profile-controller --channel=latest/edge/pr-356 
  ```
3. log in to the dashboard and create a namespace
4. check `AuthorizationPolicy` objects in the user's namespace, expect 2 objects:
  ```
  kubectl get authorizationpolicies.security.istio.io -n admin
  NAME                            AGE
  ns-owner-access-istio-charmed   15s
  ns-owner-access-istio           12s
  ```
5. create a notebook and verify there are no 403 logs from the `jupyter-controller` container
6. create a data passing pipeline and verify that you can download artifacts from pipeline steps