### PR TITLE
fix: include namespace in metadata-grpc-service host name 

### DIFF
--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -49,7 +49,7 @@ KFP_IMAGES_VERSION = "2.0.2"
 # This service name must be the Service from the mlmd-operator
 # FIXME: leaving it hardcoded now, but we should share this
 # host and port through relation data
-METADATA_GRPC_SERVICE_HOST = "metadata-grpc-service"
+METADATA_GRPC_SERVICE_HOST = "metadata-grpc-service.kubeflow"
 METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")


### PR DESCRIPTION
fix: use full svc name and namespace for METADATA_GRPC_SERVICE_HOST env var
    
The METADATA_GRPC_SERVICE_HOST env var has to include the name and namespace of the metadata grpc server, otherwise pipeline runs end in errors when trying to write in the metadata SQLite DB.

This commit reverts [this](https://github.com/canonical/kfp-operators/pull/331/files#diff-7bc4c9be60a555e7b6b00f5fcb1d401ef662bd2853cf38f3b7d9a6d03ce54aa2R52) change introduced in a previous PR.