### PR TITLE
Update bug_report.yml to remove shell attribute in logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,6 @@ body:
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
         Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs
         at https://juju.is/docs/olm/juju-logs
-      render: shell
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Logs are saved as shell input, which means they get rendered directly as a code block in the final output.  Let's change this to not be rendered.

The motivation for this is to enable something like [this issue's logs](https://github.com/canonical/kfp-operators/issues/367#issue-1972405752), where we can use a `<details> ... </details>` block to hide the logs in an expandable text block.  If the logs are rendered as shell, the user cannot do this.