### PR TITLE
fix: remove istio objects from manifests

### DIFF
--- a/charms/kfp-profile-controller/src/templates/crd_manifests.yaml.j2
+++ b/charms/kfp-profile-controller/src/templates/crd_manifests.yaml.j2
@@ -23,14 +23,16 @@ spec:
     resource: services
     updateStrategy:
       method: InPlace
-  - apiVersion: networking.istio.io/v1alpha3
-    resource: destinationrules
-    updateStrategy:
-      method: InPlace
-  - apiVersion: security.istio.io/v1beta1
-    resource: authorizationpolicies
-    updateStrategy:
-      method: InPlace
+  # istio objects are intentionally omitted from Charmed Kubeflow.
+  # kfp-profile-controller currently does not use them, see in the sync.py.
+  # - apiVersion: networking.istio.io/v1alpha3
+  #   resource: destinationrules
+  #   updateStrategy:
+  #     method: InPlace
+  # - apiVersion: security.istio.io/v1beta1
+  #   resource: authorizationpolicies
+  #   updateStrategy:
+  #     method: InPlace
   hooks:
     sync:
       webhook:


### PR DESCRIPTION
removes from `crd_manifests.yaml.j2` the istio resources not used by `kfp-profile-controller`. the resources removed are:
  * destinationrules
  * authorizationpolicies

this introduced a bug where metacontroller has a dependency on istio, whereas we are disabling istio in the sync.py
closes #373 , more details in the issue.