### PR TITLE
bump image versions to 2.0.2 to match kf 1.8 release

### DIFF
--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/api-server:2.0.2
+    upstream-source: gcr.io/ml-pipeline/api-server:2.0.3
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: gcr.io/ml-pipeline/metadata-writer:2.0.2
+    upstream-source: gcr.io/ml-pipeline/metadata-writer:2.0.3
 requires:
   grpc:
     interface: grpc

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.2
+    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.0.3
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -45,7 +45,7 @@ K8S_RESOURCE_FILES = [
     "src/templates/secrets.yaml.j2",
 ]
 KFP_DEFAULT_PIPELINE_ROOT = ""
-KFP_IMAGES_VERSION = "2.0.2"
+KFP_IMAGES_VERSION = "2.0.3"
 # This service name must be the Service from the mlmd-operator
 # FIXME: leaving it hardcoded now, but we should share this
 # host and port through relation data

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,4 +11,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.2
+    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.0.3

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: gcr.io/ml-pipeline/frontend:2.0.2
+    upstream-source: gcr.io/ml-pipeline/frontend:2.0.3
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.2
+    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.0.3

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.2
+    upstream-source: gcr.io/ml-pipeline/visualization-server:2.0.3
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
matches images cited in https://github.com/kubeflow/manifests/releases/tag/v1.8.0