### PR TITLE
fix: reduce flakiness of kfp-api integration tests

### DIFF
--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -86,9 +86,6 @@ class TestCharm:
         await ops_test.model.wait_for_idle(
             apps=["mysql-k8s"],
             status="active",
-            # mysql-k8s sometimes goes into error and then resolves itself.  Do not raise on error
-            # here so we don't flake the test when the situation will resolve itself.
-            raise_on_error=False,
             raise_on_blocked=True,
             timeout=90 * 30,
             idle_period=20,

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -79,7 +79,7 @@ class TestCharm:
         # deploy mysql-k8s charm
         await ops_test.model.deploy(
             "mysql-k8s",
-            channel="8.0/edge",
+            channel="8.0/stable",
             config={"profile": "testing"},
             trust=True,
         )

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -86,6 +86,9 @@ class TestCharm:
         await ops_test.model.wait_for_idle(
             apps=["mysql-k8s"],
             status="active",
+            # mysql-k8s sometimes goes into error and then resolves itself.  Do not raise on error
+            # here so we don't flake the test when the situation will resolve itself.
+            raise_on_error=False,
             raise_on_blocked=True,
             timeout=90 * 30,
             idle_period=20,


### PR DESCRIPTION
The mysql-k8s charm during deployment sometimes lands temporarily in an error state.  This error state resolves over time and the charm continues on to work as expected, but causes our integration tests to fail (like [this example](https://github.com/canonical/kfp-operators/actions/runs/6907962624/job/18796234535?pr=385#step:5:232)) because we do `wait_for_idle(['mysql-k8s'], ...raise_on_error=True)`.  ~~This fix sets `raise_on_error=False` to avoid this.~~

~~This does not change the passing condition of the test - the test will only pass if mysql-k8s goes to Active/Idle.  The only change is that mysql-k8s going to Error state does not result in a fast failure - the test will continue until the timeout before failing.~~

Edit on 2023-11-20: rather than set `raise_on_error=True`, the solution is now to bump the mysql version to `latest/stable` as it did not show the same same flaky behaviour.  