### PR TITLE
add service `minio-service` to kfp api to patch upstream kfp bug

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -100,7 +100,10 @@ jobs:
           charmcraft-channel: latest/candidate
 
       - run: |
-          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration"
+          # Requires the model to be called kubeflow due to
+          # https://github.com/canonical/kfp-operators/issues/389
+          juju add-model kubeflow
+          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- --model kubeflow"
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -113,6 +113,7 @@ jobs:
     name: Test the bundle
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         sdk:
           - v1

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -99,7 +99,8 @@ jobs:
           juju-channel: 3.1/stable
           charmcraft-channel: latest/candidate
 
-      - run: |
+      - name: Integration tests
+        run: |
           # Requires the model to be called kubeflow due to
           # https://github.com/canonical/kfp-operators/issues/389
           juju add-model kubeflow

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -77,14 +77,6 @@ class KfpApiOperator(CharmBase):
         self._database_name = "mlpipeline"
         self._container = self.unit.get_container(self._container_name)
 
-        # setup context to be used for updating K8S resources
-        self._context = {
-            "app_name": self._name,
-            "namespace": self._namespace,
-            "service": self._name,
-            "grpc_port": self._grcp_port,
-            "http_port": self._http_port,
-        }
         self._k8s_resource_handler = None
 
         grpc_port = ServicePort(int(self._grcp_port), name="grpc-port")
@@ -159,6 +151,21 @@ class KfpApiOperator(CharmBase):
     def container(self):
         """Return container."""
         return self._container
+
+    @property
+    def _context(self):
+        """Return the context used for generating kubernetes resources."""
+        interfaces = self._get_interfaces()
+        os = self._get_object_storage(interfaces)
+
+        context = {
+            "app_name": self._name,
+            "namespace": self._namespace,
+            "service": self._name,
+            "grpc_port": self._grcp_port,
+            "http_port": self._http_port,
+        }
+        return context
 
     @property
     def k8s_resource_handler(self):

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -157,7 +157,7 @@ class KfpApiOperator(CharmBase):
     def _context(self):
         """Return the context used for generating kubernetes resources."""
         interfaces = self._get_interfaces()
-        os = self._get_object_storage(interfaces)
+        object_storage = self._get_object_storage(interfaces)
 
         context = {
             "app_name": self._name,
@@ -166,8 +166,8 @@ class KfpApiOperator(CharmBase):
             "grpc_port": self._grcp_port,
             "http_port": self._http_port,
             # Must include .svc.cluster.local for DNS resolution
-            "minio_url": f"{os['service']}.{os['namespace']}.svc.cluster.local",
-            "minio_port": str(os["port"]),
+            "minio_url": f"{object_storage['service']}.{object_storage['namespace']}.svc.cluster.local",
+            "minio_port": str(object_storage["port"]),
         }
         return context
 

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -159,6 +159,8 @@ class KfpApiOperator(CharmBase):
         interfaces = self._get_interfaces()
         object_storage = self._get_object_storage(interfaces)
 
+        minio_url = f"{object_storage['service']}.{object_storage['namespace']}.svc.cluster.local"
+
         context = {
             "app_name": self._name,
             "namespace": self._namespace,
@@ -166,7 +168,7 @@ class KfpApiOperator(CharmBase):
             "grpc_port": self._grcp_port,
             "http_port": self._http_port,
             # Must include .svc.cluster.local for DNS resolution
-            "minio_url": f"{object_storage['service']}.{object_storage['namespace']}.svc.cluster.local",
+            "minio_url": minio_url,
             "minio_port": str(object_storage["port"]),
         }
         return context
@@ -294,7 +296,8 @@ class KfpApiOperator(CharmBase):
 
     def _check_model_name(self):
         if self.model.name != "kubeflow":
-            # Remove when this bug is resolved: https://github.com/canonical/kfp-operators/issues/389
+            # Remove when this bug is resolved:
+            # https://github.com/canonical/kfp-operators/issues/389
             raise ErrorWithStatus(
                 "kfp-api must be deployed to model named `kubeflow` due to"
                 " https://github.com/canonical/kfp-operators/issues/389",

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -292,6 +292,15 @@ class KfpApiOperator(CharmBase):
 
         return env_vars
 
+    def _check_model_name(self):
+        if self.model.name != "kubeflow":
+            # Remove when this bug is resolved: https://github.com/canonical/kfp-operators/issues/389
+            raise ErrorWithStatus(
+                "kfp-api must be deployed to model named `kubeflow` due to"
+                " https://github.com/canonical/kfp-operators/issues/389",
+                BlockedStatus,
+            )
+
     def _check_status(self):
         """Check status of workload and set status accordingly."""
         self._check_leader()
@@ -679,6 +688,7 @@ class KfpApiOperator(CharmBase):
     def _on_event(self, event, force_conflicts: bool = False) -> None:
         # Set up all relations/fetch required data
         try:
+            self._check_model_name()
             self._check_leader()
             self._apply_k8s_resources(force_conflicts=force_conflicts)
             update_layer(self._container_name, self._container, self._kfp_api_layer, self.logger)

--- a/charms/kfp-api/src/templates/minio-service.yaml.j2
+++ b/charms/kfp-api/src/templates/minio-service.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  namespace: '{{ namespace }}'
+spec:
+  type: ExternalName
+  externalName: {{ minio_url }}
+  ports:
+    - name: minio
+      protocol: TCP
+      port: 9000
+      targetPort: {{ minio_port }}

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -86,9 +86,6 @@ class TestCharm:
         await ops_test.model.wait_for_idle(
             apps=["mysql-k8s"],
             status="active",
-            # mysql-k8s sometimes goes into error and then resolves itself.  Do not raise on error
-            # here so we don't flake the test when the situation will resolve itself.
-            raise_on_error=False,
             raise_on_blocked=True,
             timeout=90 * 30,
             idle_period=20,

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -86,6 +86,9 @@ class TestCharm:
         await ops_test.model.wait_for_idle(
             apps=["mysql-k8s"],
             status="active",
+            # mysql-k8s sometimes goes into error and then resolves itself.  Do not raise on error
+            # here so we don't flake the test when the situation will resolve itself.
+            raise_on_error=False,
             raise_on_blocked=True,
             timeout=90 * 30,
             idle_period=20,

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -4,9 +4,9 @@
 from contextlib import nullcontext as does_not_raise
 from unittest.mock import MagicMock, patch
 
-from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 import pytest
 import yaml
+from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -22,7 +22,7 @@ def mocked_resource_handler(mocker):
     mocked_resource_handler_factory = mocker.patch("charm.KubernetesResourceHandler")
 
     def return_krh_with_mocked_lightkube(*args, **kwargs):
-        kwargs['lightkube_client'] = MagicMock()
+        kwargs["lightkube_client"] = MagicMock()
         return KubernetesResourceHandler(*args, **kwargs)
 
     mocked_resource_handler_factory.side_effect = return_krh_with_mocked_lightkube
@@ -703,9 +703,11 @@ class TestCharm:
 
         # Mock the KubernetesResourceHandler to always have a mocked Lightkube Client
         mocked_resource_handler_factory = mocker.patch("charm.KubernetesResourceHandler")
+
         def return_krh_with_mocked_lightkube(*args, **kwargs):
-            kwargs['lightkube_client'] = MagicMock()
+            kwargs["lightkube_client"] = MagicMock()
             return KubernetesResourceHandler(*args, **kwargs)
+
         mocked_resource_handler_factory.side_effect = return_krh_with_mocked_lightkube
 
         # Act


### PR DESCRIPTION
This adds to kfp-api a service called `minio-service` which points to the related object-storage's s3 service.  This has been added to address a bug in upstream kfp, as explained [here](https://github.com/canonical/minio-operator/pull/151).  This service was originally added to the minio charm in [minio pr 151](https://github.com/canonical/minio-operator/pull/151), but has been refactored so it is added here instead as described in [minio issue 153](https://github.com/canonical/minio-operator/issues/153).

### Reviewer notes
* All lint and unit tests should pass.  The kfp-api integration tests should pass, but the bundle tests may fail (are being fixed in a separate parallel PR)
* to manually test:
  * deploy kfp-api and required dependencies (an easy way to do this is to run `tox -e integration -- --model kubeflow -k "build_and_deploy or relational_db_relation_with_mysql_relation"`, or just to manually do the same deployments as the integration test)
  * see if the `svc/minio-service` exists (`kubectl get svc minio-service`)
  * manually use minio through the service
    * deploy a pod with the minio client (mc) and run bash in the pod: `kubectl run mc -it --rm --image minio/mc --command -- /bin/bash`
    * in the pod, do: 
      * `mc alias set myMinio http://minio-service.kubeflow:9000 ACCESSKEY SECRETKEY` (get accesskey/secretkey from juju config by inspecting kfp-api's relation with the minio charm)
      * `mc mb myMinio/testbucket`
      * `mc ls myMinio`  # (should see your testBucket)

~~Merge after #385 and #386.~~ - Done