### PR TITLE
fix(ci): Use mysql-k8s from `8.0/edge`

### DIFF
--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -77,9 +77,11 @@ class TestCharm:
     async def test_relational_db_relation_with_mysql_relation(self, ops_test: OpsTest):
         """Test failure of addition of relational-db relation with mysql relation present."""
         # deploy mysql-k8s charm
+        # We should use `8.0/stable` once changes for 
+        # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
         await ops_test.model.deploy(
             "mysql-k8s",
-            channel="8.0/stable",
+            channel="8.0/edge",
             config={"profile": "testing"},
             trust=True,
         )

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -77,7 +77,7 @@ class TestCharm:
     async def test_relational_db_relation_with_mysql_relation(self, ops_test: OpsTest):
         """Test failure of addition of relational-db relation with mysql relation present."""
         # deploy mysql-k8s charm
-        # We should use `8.0/stable` once changes for 
+        # We should use `8.0/stable` once changes for
         # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
         await ops_test.model.deploy(
             "mysql-k8s",

--- a/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
@@ -23,8 +23,8 @@ applications:
       default-gateway: kubeflow-gateway
     trust: true
   kfp-db:
-    charm: mysql-k8s
-    channel: 8.0/stable
+    charm: mysql-k8s # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     options:
       profile: testing

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -4,7 +4,8 @@ applications:
   argo-controller:         { charm: ch:argo-controller, channel: latest/edge, scale: 1, trust: true }
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: latest/edge,       scale: 1 }
-  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
+  # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/edge, scale: 1, constraints: mem=2G, trust: true }
   mlmd:                    { charm: ch:mlmd, channel: latest/edge, scale: 1 }
   envoy:                   { charm: ch:envoy, channel: latest/edge, scale: 1 }
   kubeflow-profiles:       { charm: ch:kubeflow-profiles, channel: latest/edge, scale: 1, trust: true }


### PR DESCRIPTION
Deploy `mysql-k8s` charm from `8.0/edge` channel in all of our integration tests to address #377. This issue appeared in all our integration tests that deployed the charm. Fix was published in `revision 119` as mentioned in https://github.com/canonical/mysql-k8s-operator/issues/337#issuecomment-1896598221. I also included a comment about moving back to `stable` once the fix is published there too.

Closes #377