### PR TITLE
ci: Decrease root-reserve-mb to fit the new runner storage (#406)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'
@@ -128,7 +128,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'


### PR DESCRIPTION
backports 5767624da960432766ae748c4c53aa383d07a533 to `track/2.0`
addresses canonical/bundle-kubeflow#813