### PR TITLE
Bump KFP Controller Python image

### DIFF
--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image for kfp-profile-controller
-    upstream-source: python:3.7
+    upstream-source: python:3.10
   # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
 requires:
   object-storage:


### PR DESCRIPTION
The KFP Profile Controller is using Python 3.7 which has 7 Critical CVEs. Updating the image to a newer version to reduce the number of CVEs.

I tested the above image on upstream KF and 
1. The KFP Profile Controller pod runs as expected without errors
2. the workloads were successfully replicated to user namespaces 