### PR TITLE
Support functionality to override default images for kfp-profile-controller

### DIFF
--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  custom_images:
+    type: string
+    default: | 
+      visualization_server : ''
+      frontend_image : ''
+    description: >
+      YAML or JSON formatted input defining images to use in Katib
+      For usage details, see https://github.com/canonical/kfp-operators.

--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,0 +1,4 @@
+{
+    "visualization_server": "gcr.io/ml-pipeline/visualization-server:2.0.3",
+    "frontend": "gcr.io/ml-pipeline/frontend:2.0.3"
+}

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -169,7 +169,10 @@ def validate_profile_resources(
 def validate_profile_deployments_with_custom_images(
     lightkube_client: lightkube.Client,
     profile_name: str,
+    frontend_image: str,
+    visualisation_image: str,
 ):
+    """Tests if profile's deployment have correct images"""
     # Get deployments
     pipeline_ui_deployment = lightkube_client.get(
         Deployment, name="ml-pipeline-ui-artifact", namespace=profile_name
@@ -179,10 +182,10 @@ def validate_profile_deployments_with_custom_images(
     )
 
     # Assert images
-    assert pipeline_ui_deployment.spec.template.spec.containers[0].image == CUSTOM_FRONTEND_IMAGE
+    assert pipeline_ui_deployment.spec.template.spec.containers[0].image == frontend_image
     assert (
         visualization_server_deployment.spec.template.spec.containers[0].image
-        == CUSTOM_VISUALISATION_IMAGE
+        == visualisation_image
     )
 
 
@@ -234,6 +237,7 @@ async def test_minio_config_changed(ops_test: OpsTest):
 
 
 async def test_change_custom_images(ops_test: OpsTest):
+    """Tests if the unit goes to active state after changing config with custom images."""
     custom_images = {
         "visualization_server": CUSTOM_VISUALISATION_IMAGE,
         "frontend": CUSTOM_FRONTEND_IMAGE,
@@ -248,4 +252,7 @@ async def test_change_custom_images(ops_test: OpsTest):
 
 
 async def test_new_images(lightkube_client: lightkube.Client, profile: str):
-    validate_profile_deployments_with_custom_images(lightkube_client, profile)
+    """Tests if the newly created profile has correct images"""
+    validate_profile_deployments_with_custom_images(
+        lightkube_client, profile, CUSTOM_FRONTEND_IMAGE, CUSTOM_VISUALISATION_IMAGE
+    )

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -236,7 +236,7 @@ async def test_minio_config_changed(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
-async def test_change_custom_images(ops_test: OpsTest):
+async def test_change_custom_images(ops_test: OpsTest, profile: str):
     """Tests if the unit goes to active state after changing config with custom images."""
     custom_images = {
         "visualization_server": CUSTOM_VISUALISATION_IMAGE,
@@ -250,9 +250,6 @@ async def test_change_custom_images(ops_test: OpsTest):
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=300
     )
 
-
-async def test_new_images(lightkube_client: lightkube.Client, profile: str):
-    """Tests if the newly created profile has correct images"""
     validate_profile_deployments_with_custom_images(
         lightkube_client, profile, CUSTOM_FRONTEND_IMAGE, CUSTOM_VISUALISATION_IMAGE
     )

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -151,6 +151,7 @@ def validate_profile_resources(
     assert expected_label in namespace.metadata.labels
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
+
 @retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
     stop=stop_after_delay(30),
@@ -221,6 +222,7 @@ async def test_minio_config_changed(ops_test: OpsTest):
     assert_minio_secret(minio_access_key, minio_secret_key, ops_test)
 
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
 
 async def test_change_custom_images(ops_test: OpsTest):
     custom_images = {

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -236,7 +236,7 @@ async def test_minio_config_changed(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
-async def test_change_custom_images(ops_test: OpsTest, profile: str):
+async def test_change_custom_images(ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str):
     """Tests that updating images deployed to user Namespaces works as expected."""
     custom_images = {
         "visualization_server": CUSTOM_VISUALISATION_IMAGE,

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
 from base64 import b64decode
 from pathlib import Path
@@ -11,6 +12,7 @@ import yaml
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace, Pod, Secret, ServiceAccount
+from lightkube.resources.apps_v1 import Deployment
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_delay, wait_exponential
 
@@ -21,6 +23,8 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 MINIO_APP_NAME = "minio"
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
+CUSTOM_FRONTEND_IMAGE = "gcr.io/ml-pipeline/frontend:latest"
+CUSTOM_VISUALISATION_IMAGE = "gcr.io/ml-pipeline/visualization-server:latest"
 
 
 @pytest.mark.abort_on_fail
@@ -147,6 +151,30 @@ def validate_profile_resources(
     assert expected_label in namespace.metadata.labels
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
+@retry(
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    stop=stop_after_delay(30),
+    reraise=True,
+)
+def validate_profile_deployments_with_custom_images(
+    lightkube_client: lightkube.Client,
+    profile_name: str,
+):
+    # Get deployments
+    pipeline_ui_deployment = lightkube_client.get(
+        Deployment, name="ml-pipeline-ui-artifact", namespace=profile_name
+    )
+    visualization_server_deployment = lightkube_client.get(
+        Deployment, name="ml-pipeline-visualizationserver", namespace=profile_name
+    )
+
+    # Assert images
+    assert pipeline_ui_deployment.spec.template.spec.containers[0].image == CUSTOM_FRONTEND_IMAGE
+    assert (
+        visualization_server_deployment.spec.template.spec.containers[0].image
+        == CUSTOM_VISUALISATION_IMAGE
+    )
+
 
 async def test_model_resources(ops_test: OpsTest):
     """Tests if the resources associated with secret's namespace were created.
@@ -193,3 +221,20 @@ async def test_minio_config_changed(ops_test: OpsTest):
     assert_minio_secret(minio_access_key, minio_secret_key, ops_test)
 
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+async def test_change_custom_images(ops_test: OpsTest):
+    custom_images = {
+        "visualization_server": CUSTOM_VISUALISATION_IMAGE,
+        "frontend": CUSTOM_FRONTEND_IMAGE,
+    }
+    await ops_test.model.applications[APP_NAME].set_config(
+        {"custom_images": json.dumps(custom_images)}
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=300
+    )
+
+
+async def test_new_images(lightkube_client: lightkube.Client, profile: str):
+    validate_profile_deployments_with_custom_images(lightkube_client, profile)

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -236,7 +236,9 @@ async def test_minio_config_changed(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
-async def test_change_custom_images(ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str):
+async def test_change_custom_images(
+    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
+):
     """Tests that updating images deployed to user Namespaces works as expected."""
     custom_images = {
         "visualization_server": CUSTOM_VISUALISATION_IMAGE,

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -60,13 +60,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
         entity_url="kubeflow-profiles",
-        # TODO: Revert once kubeflow-profiles stable supports k8s 1.22
         channel="1.7/stable",
         trust=True,
     )
     await ops_test.model.deploy(
         entity_url="metacontroller-operator",
-        # TODO: Revert once metacontroller stable supports k8s 1.22
         channel="2.0/stable",
         trust=True,
     )

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -237,7 +237,7 @@ async def test_minio_config_changed(ops_test: OpsTest):
 
 
 async def test_change_custom_images(ops_test: OpsTest, profile: str):
-    """Tests if the unit goes to active state after changing config with custom images."""
+    """Tests that updating images deployed to user Namespaces works as expected."""
     custom_images = {
         "visualization_server": CUSTOM_VISUALISATION_IMAGE,
         "frontend": CUSTOM_FRONTEND_IMAGE,


### PR DESCRIPTION
This PR fixes https://github.com/canonical/bundle-kubeflow/issues/851 for 1.7.1 kubeflow

New functionality:
- User can override images for `ui-artifact` and `visualizationserver` pods through custom-images config setting.
- Added integration tests which checks that the config change succeeds and that the new profile will have deployments with different images. 

Changes in integration tests 
- had to pin all latest/edge charms 
- now I am also deploying admission webhook so I can check that the resources are really created

CI passes except bundle tests which was previously observed in https://github.com/canonical/kfp-operators/issues/399