### PR TITLE
Fix integration tests for kfp-profile-controller for `track/2.0-alpha.7`

### DIFF
--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -31,13 +31,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}
 
-    # Deploy the admission webhook to apply the PodDefault CRD required by the charm workload
-    await ops_test.model.deploy(entity_url="admission-webhook", channel="1.7/stable", trust=True)
-    # TODO: The webhook charm must be active before the metacontroller is deployed, due to the bug
-    # described here: https://github.com/canonical/metacontroller-operator/issues/86
-    # Drop this wait_for_idle once the above issue is closed
-    await ops_test.model.wait_for_idle(apps=["admission-webhook"], status="active")
-    
     await ops_test.model.deploy(
         entity_url=built_charm_path,
         application_name=APP_NAME,
@@ -54,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
         entity_url="kubeflow-profiles",
-        channel="2.0-alpha.7/stable",
+        channel="1.7/stable",
         trust=True,
     )
     await ops_test.model.deploy(

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -31,6 +31,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}
 
+    # Deploy the admission webhook to apply the PodDefault CRD required by the charm workload
+    await ops_test.model.deploy(entity_url="admission-webhook", channel="1.7/stable", trust=True)
+    # TODO: The webhook charm must be active before the metacontroller is deployed, due to the bug
+    # described here: https://github.com/canonical/metacontroller-operator/issues/86
+    # Drop this wait_for_idle once the above issue is closed
+    await ops_test.model.wait_for_idle(apps=["admission-webhook"], status="active")
+    
     await ops_test.model.deploy(
         entity_url=built_charm_path,
         application_name=APP_NAME,

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -47,19 +47,17 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(
         entity_url="kubeflow-profiles",
-        # TODO: Revert once kubeflow-profiles stable supports k8s 1.22
-        channel="latest/edge",
+        channel="2.0-alpha.7/stable",
         trust=True,
     )
     await ops_test.model.deploy(
         entity_url="metacontroller-operator",
-        # TODO: Revert once metacontroller stable supports k8s 1.22
-        channel="latest/edge",
+        channel="2.0/stable",
         trust=True,
     )
 
     # Maybe: await ops_test.model.wait_for_idle(raise_on_error=False, raise_on_blocked=True) ?
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
+    await ops_test.model.wait_for_idle(status="active", timeout=60 * 10, raise_on_error=False)
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Fixes: https://github.com/canonical/kfp-operators/issues/422

- Fix disk space for github runners 
- Pin versions of charms in integration tests 
- Add `raise on failure false` flag while waiting for deployment

NOTE: failing integration tests for kfp-api and bundle are addressed in separate PRs