### PR TITLE
backport fix bundle_v2 integration tests failures due to running out of space on `track/2.0`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -79,18 +79,14 @@ jobs:
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
       # This action will remove unused software (dotnet, haskell, android libs, codeql,
-      # and docker images) from the GH runner, which will liberate around 60 GB of storage
-      # distributed in 40GB for root and around 20 for a mnt point.
+      # and docker images) from the GH runner.
+      # This leaves ~45GB free as of 2024-04-10, but this amount has varied as GH changed their
+      # runners
       - name: Maximise GH runner space
-        uses: easimon/maximize-build-space@v7
-        with:
-          root-reserve-mb: 29696
-          remove-dotnet: 'true'
-          remove-haskell: 'true'
-          remove-android: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+        uses: jlumbroso/free-disk-space@v1.3.1
+
       - uses: actions/checkout@v3
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -123,17 +119,11 @@ jobs:
       # This is a workaround for https://github.com/canonical/kfp-operators/issues/250
       # Ideally we'd use self-hosted runners, but this effort is still not stable
       # This action will remove unused software (dotnet, haskell, android libs, codeql,
-      # and docker images) from the GH runner, which will liberate around 60 GB of storage
-      # distributed in 40GB for root and around 20 for a mnt point.
+      # and docker images) from the GH runner.
+      # This leaves ~45GB free as of 2024-04-10, but this amount has varied as GH changed their
+      # runners
       - name: Maximise GH runner space
-        uses: easimon/maximize-build-space@v7
-        with:
-          root-reserve-mb: 29696
-          remove-dotnet: 'true'
-          remove-haskell: 'true'
-          remove-android: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Backports #428 to `track/2.0`