### PR TITLE
fix: Pin integration test dependencies in main

### DIFF
--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -19,7 +19,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 KFP_DB = "kfp-db"
 KFP_DB_CHANNEL = "latest/edge"
 KFP_DB_CONFIG = {"database": "mlpipeline"}
-KFP_DB_ENTITY = "charmed-osm-mariadb-k8s"
+MARIADB_CHARM = "charmed-osm-mariadb-k8s"
 KFP_DB_TRUST = True
 KFP_VIZ = "kfp-viz"
 KFP_VIZ_CHANNEL = "latest/edge"
@@ -67,7 +67,7 @@ class TestCharm:
         # 1) The team has acceped and started using mysql-k8s more extensively
         # 2) The repository level integration tests use mysql-k8s only
         await ops_test.model.deploy(
-            entity_url=KFP_DB_ENTITY,
+            entity_url=MARIADB_CHARM,
             application_name=KFP_DB,
             config=KFP_DB_CONFIG,
             channel=KFP_DB_CHANNEL,

--- a/charms/kfp-api/tests/integration/test_charm.py
+++ b/charms/kfp-api/tests/integration/test_charm.py
@@ -17,10 +17,10 @@ APP_NAME = "kfp-api"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 KFP_DB = "kfp-db"
-KFP_DB_CHANNEL = "latest/edge"
-KFP_DB_CONFIG = {"database": "mlpipeline"}
+MARIADB_CHANNEL = "latest/edge"
+MARIADB_CONFIG = {"database": "mlpipeline"}
 MARIADB_CHARM = "charmed-osm-mariadb-k8s"
-KFP_DB_TRUST = True
+MARIADB_TRUST = True
 KFP_VIZ = "kfp-viz"
 KFP_VIZ_CHANNEL = "latest/edge"
 KFP_VIZ_TRUST = True
@@ -69,9 +69,9 @@ class TestCharm:
         await ops_test.model.deploy(
             entity_url=MARIADB_CHARM,
             application_name=KFP_DB,
-            config=KFP_DB_CONFIG,
-            channel=KFP_DB_CHANNEL,
-            trust=KFP_DB_TRUST,
+            config=MARIADB_CONFIG,
+            channel=MARIADB_CHANNEL,
+            trust=MARIADB_TRUST,
         )
         await ops_test.model.deploy(
             entity_url=MINIO, config=MINIO_CONFIG, channel=MINIO_CHANNEL, trust=MINIO_TRUST

--- a/charms/kfp-persistence/tests/integration/test_charm.py
+++ b/charms/kfp-persistence/tests/integration/test_charm.py
@@ -13,8 +13,21 @@ logger = logging.getLogger(__name__)
 APP_NAME = "kfp-persistence"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
+KFP_API = "kfp-api"
+KFP_API_CHANNEL = "latest/edge"
+KFP_API_TRUST = True
+KFP_DB = "kfp-db"
+KFP_DB_CHANNEL = "8.0/stable"
+KFP_DB_CONFIG = {"profile": "testing"}
+KFP_DB_ENTITY = "mysql-k8s"
+KFP_DB_TRUST = True
+KFP_VIZ = "kfp-viz"
+KFP_VIZ_CHANNEL = "latest/edge"
+KFP_VIZ_TRUST = True
+MINIO_CHANNEL = "latest/edge"
+MINIO = "minio"
+MINIO_TRUST = True
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
-KFP_DB_CONFIG = {"database": "mlpipeline"}
 
 
 class TestCharm:
@@ -37,27 +50,31 @@ class TestCharm:
         )
 
         await ops_test.model.deploy(
-            entity_url="mysql-k8s",
-            application_name="kfp-db",
-            config={"profile": "testing"},
-            channel="8.0/edge",
-            trust=True,
+            entity_url=KFP_DB_ENTITY,
+            application_name=KFP_DB,
+            config=KFP_DB_CONFIG,
+            channel=KFP_DB_CHANNEL,
+            trust=KFP_DB_TRUST,
         )
 
         await ops_test.model.deploy(
-            entity_url="minio", config=MINIO_CONFIG, channel="ckf-1.7/stable", trust=True
+            entity_url=MINIO, config=MINIO_CONFIG, channel=MINIO_CHANNEL, trust=MINIO_TRUST
         )
-        await ops_test.model.deploy(entity_url="kfp-viz", channel="2.0/stable", trust=True)
+        await ops_test.model.deploy(
+            entity_url=KFP_VIZ, channel=KFP_VIZ_CHANNEL, trust=KFP_VIZ_TRUST
+        )
 
         # deploy kfp-api which needs to be related to this charm
-        await ops_test.model.deploy(entity_url="kfp-api", channel="2.0/stable", trust=True)
+        await ops_test.model.deploy(
+            entity_url=KFP_API, channel=KFP_API_CHANNEL, trust=KFP_API_TRUST
+        )
 
-        await ops_test.model.add_relation("kfp-api:relational-db", "kfp-db:database")
-        await ops_test.model.add_relation("kfp-api:object-storage", "minio:object-storage")
-        await ops_test.model.add_relation("kfp-api:kfp-viz", "kfp-viz:kfp-viz")
+        await ops_test.model.add_relation(f"{KFP_API}:relational-db", f"{KFP_DB}:database")
+        await ops_test.model.add_relation(f"{KFP_API}:object-storage", f"{MINIO}:object-storage")
+        await ops_test.model.add_relation(f"{KFP_API}:kfp-viz", f"{KFP_VIZ}:kfp-viz")
 
         await ops_test.model.wait_for_idle(
-            apps=["kfp-api", "kfp-db"],
+            apps=[KFP_API, KFP_DB],
             status="active",
             raise_on_blocked=False,
             raise_on_error=False,
@@ -65,7 +82,7 @@ class TestCharm:
             idle_period=30,
         )
 
-        await ops_test.model.add_relation(f"{APP_NAME}:kfp-api", "kfp-api:kfp-api")
+        await ops_test.model.add_relation(f"{APP_NAME}:kfp-api", f"{KFP_API}:kfp-api")
 
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,7 @@ This directory has the following structure:
 ├── README.md
 └── integration
     ├── bundles
+    |   ├── kfp_1.8_stable_install.yaml.j2
     │   ├── kfp_1.7_stable_install.yaml.j2
     │   └── kfp_latest_edge.yaml.j2
     ├── conftest.py

--- a/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
@@ -1,0 +1,94 @@
+bundle: kubernetes
+name: kubeflow-pipelines
+applications:
+  argo-controller:         { charm: ch:argo-controller, channel: 3.3.10/stable, scale: 1, trust: true }
+  metacontroller-operator: { charm: ch:metacontroller-operator, channel: 3.0/stable, scale: 1, trust: true }
+  minio:                   { charm: ch:minio, channel: ckf-1.8/stable,       scale: 1 }
+  # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
+  mlmd:                    { charm: ch:mlmd, channel: 1.14/stable, scale: 1 }
+  envoy:                   { charm: ch:envoy, channel: 2.0/stable, scale: 1 }
+  kubeflow-profiles:       { charm: ch:kubeflow-profiles, channel: 1.8/stable, scale: 1, trust: true }
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.17/stable
+    scale: 1
+    options:
+      kind: ingress
+    trust: true
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.17/stable
+    scale: 1
+    options:
+      default-gateway: kubeflow-gateway
+    trust: true
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.8/stable
+    scale: 1
+    trust: true
+{%- if local_build == false %}
+  kfp-api:                 { charm: ch:kfp-api, channel: 2.0/stable, scale: 1, trust: true}
+  kfp-metadata-writer:     { charm: ch:kfp-metadata-writer, channel: 2.0/stable, scale: 1, trust: true}
+  kfp-persistence:         { charm: ch:kfp-persistence, channel: 2.0/stable, scale: 1, trust: true }
+  kfp-profile-controller:  { charm: ch:kfp-profile-controller, channel: 2.0/stable, scale: 1, trust: true }
+  kfp-schedwf:             { charm: ch:kfp-schedwf, channel: 2.0/stable, scale: 1, trust: true}
+  kfp-ui:                  { charm: ch:kfp-ui, channel: 2.0/stable, trust: true,            scale: 1 }
+  kfp-viewer:              { charm: ch:kfp-viewer, channel: 2.0/stable, trust: true,         scale: 1 }
+  kfp-viz:                 { charm: ch:kfp-viz, channel: 2.0/stable, trust: true,         scale: 1 }
+{%- else %}
+  kfp-api:
+    charm: {{ kfp_api }}
+    resources: {{ kfp_api_resources }}
+    scale: 1
+    trust: true
+  kfp-metadata-writer:
+    charm: {{ kfp_metadata_writer }}
+    resources: {{ kfp_metadata_writer_resources }}
+    scale: 1
+    trust: true
+  kfp-persistence:
+    charm: {{ kfp_persistence }}
+    resources: {{ kfp_persistence_resources }}
+    scale: 1
+    trust: true
+  kfp-profile-controller:
+    charm: {{ kfp_profile_controller }}
+    resources: {{ kfp_profile_controller_resources }}
+    scale: 1
+    trust: true
+  kfp-schedwf:
+    charm: {{ kfp_schedwf }}
+    resources: {{ kfp_schedwf_resources }}
+    scale: 1
+    trust: true
+  kfp-ui:
+    charm: {{ kfp_ui }}
+    resources: {{ kfp_ui_resources }}
+    scale: 1
+    trust: true
+  kfp-viewer:
+    charm: {{ kfp_viewer }}
+    resources: {{ kfp_viewer_resources }}
+    scale: 1
+    trust: true
+  kfp-viz:
+    charm: {{ kfp_viz }}
+    resources: {{ kfp_viz_resources }}
+    scale: 1
+    trust: true
+{%- endif %}
+relations:
+- [argo-controller:object-storage, minio:object-storage]
+- [kfp-api:relational-db, kfp-db:database]
+- [kfp-api:kfp-api, kfp-persistence:kfp-api]
+- [kfp-api:kfp-api, kfp-ui:kfp-api]
+- [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+- [kfp-api:object-storage, minio:object-storage]
+- [kfp-ui:object-storage, minio:object-storage]
+- [envoy:grpc, mlmd:grpc]
+- [kfp-metadata-writer:grpc, mlmd:grpc]
+- [envoy:ingress, istio-pilot:ingress]
+- [istio-ingressgateway:istio-pilot, istio-pilot:istio-pilot]
+- [kfp-profile-controller:object-storage, minio:object-storage]


### PR DESCRIPTION
This commit pins all charms that get deployed from Charmhub to a latest/edge or suggested versions.

Part of canonical/bundle-kubeflow#864