### PR TITLE
feat(api-server): Enable charm configuration of launcher and driver images

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -51,9 +51,11 @@ options:
     description: Default name of object storage bucket.
   launcher-image:
     type: string
-    default: ""
+    # Source: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/src/v2/compiler/argocompiler/container.go#L27
+    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
-    default: ""
+    # Source: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/src/v2/compiler/argocompiler/container.go#L29
+    default: "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707"
     description: Driver image used during a pipeline's steps.

--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -49,3 +49,11 @@ options:
     type: string
     default: "mlpipeline"
     description: Default name of object storage bucket.
+  launcher-image:
+    type: string
+    default: ""
+    description: Launcher image used during a pipeline's steps.
+  driver-image:
+    type: string
+    default: ""
+    description: Driver image used during a pipeline's steps.

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -290,6 +290,8 @@ class KfpApiOperator(CharmBase):
             "OBJECTSTORECONFIG_HOST": f"{object_storage['service']}.{object_storage['namespace']}",
             "OBJECTSTORECONFIG_PORT": str(object_storage["port"]),
             "OBJECTSTORECONFIG_REGION": "",
+            "V2_LAUNCHER_IMAGE": self.model.config["launcher-image"],
+            "V2_DRIVER_IMAGE": self.model.config["driver-image"],
         }
 
         return env_vars

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -440,8 +440,8 @@ class TestCharm:
             ),
             "OBJECTSTORECONFIG_PORT": str(objectstorage_data["port"]),
             "OBJECTSTORECONFIG_REGION": "",
-            "V2_LAUNCHER_IMAGE": "",
-            "V2_DRIVER_IMAGE": "",
+            "V2_LAUNCHER_IMAGE": "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4",  # noqa: E501
+            "V2_DRIVER_IMAGE": "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707",  # noqa: E501
         }
         test_env = pebble_plan_info["services"][KFP_API_SERVICE_NAME]["environment"]
 

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -352,14 +352,18 @@ class TestCharm:
     ):
         """Test complete installation with all required relations and verify pebble layer."""
         harness.set_leader(True)
-        kfpapi_relation_name = "kfp-api"
         model_name = "kubeflow"
         service_port = "8888"
         harness.set_model_name(model_name)
         harness.update_config({"http-port": service_port})
 
         # Set up required relations
-        mysql_data, objectstorage_data, kfp_viz_data, kfpapi_rel_id = self.setup_required_relations(harness)
+        (
+            mysql_data,
+            objectstorage_data,
+            kfp_viz_data,
+            kfpapi_rel_id,
+        ) = self.setup_required_relations(harness)
 
         harness.begin_with_initial_hooks()
         harness.container_pebble_ready(KFP_API_CONTAINER_NAME)
@@ -715,7 +719,6 @@ class TestCharm:
         assert len(minio_service.spec.ports) == 1
         assert minio_service.spec.ports[0].targetPort == objectstorage_data["port"]
 
-        
     def setup_required_relations(self, harness: Harness):
         kfpapi_relation_name = "kfp-api"
 

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -5,5 +5,5 @@
 # dynamic list
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
-IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options.cache-image |  select(.) | .default' {} \;))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options.*-image |  select(.) | .default' {} \;))
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Enable charm configuration of launcher and driver images used during pipeline steps. Those can be configured thourgh values `launcher-image` and `driver-image`. When unset, KFP uses the default images defined in upstream code. This is based on upstream implementation introduced in kubeflow/pipelines#10269.

Closes #452

#### Testing
This was tested with upstream image `gcr.io/ml-pipeline/api-server:2.0.5`. The rest of kfp used the ROCKs.

It can be tested that pipeline steps are using the proper images by configuring the charm and then running a pipeline. 
```bash
juju config kfp-api launcher-image="fake-image"
juju config kfp-api driver-image="fake-image"
```

You should see pods created by the pipeline run that spin up containers using the images provided in the config options.

Note that:
* Each configuration should be tested separately. A pod using the `launcher-image` is only spun up after (at least some) `driver-image` pods are completed. Thus, `launcher-image` configuration can only be tested when `driver-image` config is healthy.
* When rerunning the same exact pipeline, KFP will use the launcher spun up previously, if one was successfully created, instead of spinning a new one (thus the previously used `launcher-image`).