### PR TITLE
chore: bump images to KFP 2.0.5

### DIFF
--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/api-server:2.0.3-e037d33
+    upstream-source: charmedkubeflow/api-server:2.0.5-63c48d5
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: charmedkubeflow/metadata-writer:2.0.3-286d4a8
+    upstream-source: charmedkubeflow/metadata-writer:2.0.5-95d0c17
 requires:
   grpc:
     interface: k8s-service

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/persistenceagent:2.0.3-a3714a9
+    upstream-source: charmedkubeflow/persistenceagent:2.0.5-8feef4e
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,4 +11,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/scheduledworkflow:2.0.3-7d6d3e4
+    upstream-source: charmedkubeflow/scheduledworkflow:2.0.5-f6d0763

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: charmedkubeflow/frontend:2.0.3-d4ac42b
+    upstream-source: gcr.io/ml-pipeline/frontend:2.0.5
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: charmedkubeflow/viewer-crd-controller:2.0.3-d89d9fc
+    upstream-source: charmedkubeflow/viewer-crd-controller:2.0.5-f28db97

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: charmedkubeflow/visualization-server:2.0.3-8169d0c
+    upstream-source: charmedkubeflow/visualization-server:2.0.5-4ae34a1
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
* Bump ROCKs to 2.0.5.
* Use upstream image for kfp-ui (frontend) due to canonical/pipelines-rocks#80.

Closes #450