### PR TITLE
chore: Update kfp-api manifests to 2.2.0

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -51,13 +51,13 @@ options:
     description: Default name of object storage bucket.
   launcher-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/src/v2/compiler/argocompiler/container.go#L27
-    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/src/v2/compiler/argocompiler/container.go#L30
+    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:8fe5e6e4718f20b021736022ad3741ddf2abd82aa58c86ae13e89736fdc3f08f"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/src/v2/compiler/argocompiler/container.go#L29
-    default: "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/src/v2/compiler/argocompiler/container.go#L32
+    default: "gcr.io/ml-pipeline/kfp-driver@sha256:3c0665cd36aa87e4359a4c8b6271dcba5bdd817815cd0496ed12eb5dde5fd2ec"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string

--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -59,3 +59,7 @@ options:
     # Source: https://github.com/kubeflow/pipelines/blob/2.0.5/backend/src/v2/compiler/argocompiler/container.go#L29
     default: "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707"
     description: Driver image used during a pipeline's steps.
+  log-level:
+    type: string
+    default: "info"
+    description: Log level of api server

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/api-server:2.0.5-63c48d5
+    upstream-source: gcr.io/ml-pipeline/api-server:2.2.0
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -273,6 +273,7 @@ class KfpApiOperator(CharmBase):
             "MULTIUSER": "true",
             "VISUALIZATIONSERVICE_NAME": viz_data["service-name"],
             "VISUALIZATIONSERVICE_PORT": viz_data["service-port"],
+            "LOG_LEVEL": self.model.config["log-level"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": viz_data["service-name"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": viz_data["service-port"],
             "CACHE_IMAGE": self.model.config["cache-image"],

--- a/charms/kfp-api/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-api/src/templates/auth_manifests.yaml.j2
@@ -52,6 +52,35 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  - conditions
+  - runs
+  - tasks
+  - customruns
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - custom.tekton.dev
+  resources:
+  - pipelineloops
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -247,6 +276,8 @@ rules:
   - clusterworkflowtemplates/finalizers
   - workflowtasksets
   - workflowtasksets/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
   verbs:
   - create
   - delete

--- a/charms/kfp-api/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-api/src/templates/auth_manifests.yaml.j2
@@ -287,3 +287,66 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ app_name }}
+    application-crd-id: kubeflow-pipelines
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-aggregate-to-edit
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ app_name }}
+    application-crd-id: kubeflow-pipelines
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-aggregate-to-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -426,6 +426,7 @@ class TestCharm:
             "MULTIUSER": "true",
             "VISUALIZATIONSERVICE_NAME": kfp_viz_data["service-name"],
             "VISUALIZATIONSERVICE_PORT": kfp_viz_data["service-port"],
+            'LOG_LEVEL': 'info',
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": kfp_viz_data["service-name"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": kfp_viz_data["service-port"],
             "CACHE_IMAGE": harness.charm.config["cache-image"],

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -440,8 +440,8 @@ class TestCharm:
             ),
             "OBJECTSTORECONFIG_PORT": str(objectstorage_data["port"]),
             "OBJECTSTORECONFIG_REGION": "",
-            "V2_LAUNCHER_IMAGE": "gcr.io/ml-pipeline/kfp-launcher@sha256:80cf120abd125db84fa547640fd6386c4b2a26936e0c2b04a7d3634991a850a4",  # noqa: E501
-            "V2_DRIVER_IMAGE": "gcr.io/ml-pipeline/kfp-driver@sha256:8e60086b04d92b657898a310ca9757631d58547e76bbbb8bfc376d654bef1707",  # noqa: E501
+            "V2_LAUNCHER_IMAGE": "gcr.io/ml-pipeline/kfp-launcher@sha256:8fe5e6e4718f20b021736022ad3741ddf2abd82aa58c86ae13e89736fdc3f08f",  # noqa: E501
+            "V2_DRIVER_IMAGE": "gcr.io/ml-pipeline/kfp-driver@sha256:3c0665cd36aa87e4359a4c8b6271dcba5bdd817815cd0496ed12eb5dde5fd2ec",  # noqa: E501
         }
         test_env = pebble_plan_info["services"][KFP_API_SERVICE_NAME]["environment"]
 

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -426,7 +426,7 @@ class TestCharm:
             "MULTIUSER": "true",
             "VISUALIZATIONSERVICE_NAME": kfp_viz_data["service-name"],
             "VISUALIZATIONSERVICE_PORT": kfp_viz_data["service-port"],
-            'LOG_LEVEL': 'info',
+            "LOG_LEVEL": harness.charm.config["log-level"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": kfp_viz_data["service-name"],
             "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": kfp_viz_data["service-port"],
             "CACHE_IMAGE": harness.charm.config["cache-image"],
@@ -441,8 +441,8 @@ class TestCharm:
             ),
             "OBJECTSTORECONFIG_PORT": str(objectstorage_data["port"]),
             "OBJECTSTORECONFIG_REGION": "",
-            "V2_LAUNCHER_IMAGE": "gcr.io/ml-pipeline/kfp-launcher@sha256:8fe5e6e4718f20b021736022ad3741ddf2abd82aa58c86ae13e89736fdc3f08f",  # noqa: E501
-            "V2_DRIVER_IMAGE": "gcr.io/ml-pipeline/kfp-driver@sha256:3c0665cd36aa87e4359a4c8b6271dcba5bdd817815cd0496ed12eb5dde5fd2ec",  # noqa: E501
+            "V2_LAUNCHER_IMAGE": harness.charm.config["launcher-image"],
+            "V2_DRIVER_IMAGE": harness.charm.config["driver-image"],
         }
         test_env = pebble_plan_info["services"][KFP_API_SERVICE_NAME]["environment"]
 


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo.

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

This PR also introduces `argo-aggregate-to-edit` and `argo-aggregate-to-view` ClusterRoles.

Closes #459