### PR TITLE
chore: Update kfp-persistence manifests to 2.2.0

### DIFF
--- a/charms/kfp-persistence/config.yaml
+++ b/charms/kfp-persistence/config.yaml
@@ -1,1 +1,5 @@
-options: {}
+options:
+  log-level:
+    type: string
+    default: "info"
+    description: Log level of persistence agent

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/persistenceagent:2.0.5-8feef4e
+    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.2.0
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-persistence/src/charm.py
+++ b/charms/kfp-persistence/src/charm.py
@@ -108,6 +108,7 @@ class KfpPersistenceOperator(CharmBase):
                 environment={
                     "KUBEFLOW_USERID_HEADER": "kubeflow-userid",
                     "KUBEFLOW_USERID_PREFIX": "",
+                    "LOG_LEVEL": self.model.config["log-level"],
                     # Upstream defines this in the configmap persistenceagent-config-*
                     "MULTIUSER": "true",
                     "NAMESPACE": "",

--- a/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-persistence/src/templates/auth_manifests.yaml.j2
@@ -38,6 +38,35 @@ rules:
   verbs:
     - reportMetrics
     - readArtifact
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  - conditions
+  - runs
+  - tasks
+  - customruns
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - custom.tekton.dev
+  resources:
+  - pipelineloops
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charms/kfp-persistence/tests/unit/test_operator.py
+++ b/charms/kfp-persistence/tests/unit/test_operator.py
@@ -154,5 +154,6 @@ def test_pebble_services_running(harness, mocked_lightkube_client):
     assert environment["MULTIUSER"] == "true"
     assert environment["KUBEFLOW_USERID_HEADER"] == "kubeflow-userid"
     assert environment["KUBEFLOW_USERID_PREFIX"] == ""
+    assert environment["LOG_LEVEL"] == harness.charm.config["log-level"]
     assert environment["TTL_SECONDS_AFTER_WORKFLOW_FINISH"] == "86400"
     assert environment["NUM_WORKERS"] == "2"


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo:

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

Closes #461