### PR TITLE
chore: Update kfp-schedwf manifests to 2.2.0

### DIFF
--- a/charms/kfp-schedwf/config.yaml
+++ b/charms/kfp-schedwf/config.yaml
@@ -3,3 +3,7 @@ options:
     type: string
     default: 'UTC'
     description: Cron schedule timezone
+  log-level:
+    type: string
+    default: "info"
+    description: Log level of scheduled workflow controller

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,4 +11,4 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/scheduledworkflow:2.0.5-f6d0763
+    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.2.0

--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -73,6 +73,7 @@ class KfpSchedwf(CharmBase):
                 container_name="ml-pipeline-scheduledworkflow",
                 service_name="controller",
                 timezone=self.model.config["timezone"],
+                log_level=self.model.config["log-level"],
                 namespace=self.model.name,
             ),
             depends_on=[self.kubernetes_resources],

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -13,12 +13,16 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self,
         *args,
         timezone: str,
+        log_level: str,
         namespace: str,
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
         super().__init__(*args, **kwargs)
-        self.environment = {"CRON_SCHEDULE_TIMEZONE": timezone}
+        self.environment = {
+            "CRON_SCHEDULE_TIMEZONE": timezone,
+            "LOG_LEVEL": log_level,
+        }
         self.namespace = namespace
 
     def get_layer(self) -> Layer:

--- a/charms/kfp-schedwf/tests/unit/test_operator.py
+++ b/charms/kfp-schedwf/tests/unit/test_operator.py
@@ -81,6 +81,7 @@ def test_pebble_service_is_replanned_on_config_changed(harness, mocked_lightkube
     # Assert the environment variables that are set from defaults
     environment = container.get_plan().services["controller"].environment
     assert environment["CRON_SCHEDULE_TIMEZONE"] == harness.charm.config.get("timezone")
+    assert environment["LOG_LEVEL"] == harness.charm.config.get("log-level")
 
 
 def test_install_before_pebble_service_container(harness, mocked_lightkube_client):


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo.

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

Closes #463