### PR TITLE
chore: Update kfp-ui manifests to 2.2.0

### DIFF
--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: gcr.io/ml-pipeline/frontend:2.0.5
+    upstream-source: gcr.io/ml-pipeline/frontend:2.2.0
 requires:
   object-storage:
     interface: object-storage


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo.

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

Closes #464