### PR TITLE
chore: Update kfp-viewer manifests to 2.2.0

### DIFF
--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,4 +12,4 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: charmedkubeflow/viewer-crd-controller:2.0.5-f28db97
+    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.2.0


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo.

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

Closes #465