### PR TITLE
chore: Update kfp-viz manifests to 2.2.0

### DIFF
--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: charmedkubeflow/visualization-server:2.0.5-4ae34a1
+    upstream-source: gcr.io/ml-pipeline/visualization-server:2.2.0
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
This is based on the following commands in https://github.com/kubeflow/manifests/ repo.

```diff
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.8.yaml
kustomize build apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user > kfp-1.9-rc.0.yaml
diff kfp-1.8.yaml kfp-1.9-rc.0.yaml > kfp-1.8-1.9-rc.0.diff
```

Closes #475