### PR TITLE
Update KFP Controller Python image to Ubuntu/python rock

### DIFF
--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image for kfp-profile-controller
-    upstream-source: python:3.7
+    upstream-source: ubuntu/python:3.8-20.04_edge
   # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
 requires:
   object-storage:

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -51,7 +51,9 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                     self.service_name: {
                         "override": "replace",
                         "summary": "entry point for kfp-profile-controller",
-                        "command": "python /hooks/sync.py",  # Must be a string
+                        # Upstream uses `python` instead of python3. We modified it in order
+                        # to be able to use ubuntu/python3.8 image.
+                        "command": "python3 /hooks/sync.py",  # Must be a string
                         "startup": "enabled",
                         "environment": {
                             "MINIO_HOST": inputs.MINIO_HOST,


### PR DESCRIPTION
The KFP Profile Controller is using Python 3.7 which has 7 Critical CVEs. Updating the image to a Canonical maintained ROCK to reduce the number of CVEs. 

**EDIT**: We should update once rockcraft team releases a `stable` version of the image as mentioned [here](https://hub.docker.com/r/ubuntu/python). This should happen in 2-3 weeks.

#### CVEs
Running the following command shows that the new image has 0 criticals.
```
docker run -v \ 
    /var/run/docker.sock:/var/run/docker.sock \
    -v `pwd`:`pwd` \
    -w `pwd` \
    --rm \
    --name=scanner \
    aquasec/trivy image --timeout 30m \
    -f json -o trivy-report.json --ignore-unfixed \
    ubuntu/python:3.8-20.04_edge
```

#### Testing
I updated kfp-profile-controller to the charm from this PR
```
juju refresh kfp-profile-controller --channel latest/edge/pr-477 --resource oci-image=ubuntu/python:3.8-20.04_edge
```
and:
1. KFP Profile Controller pod runs without errors
2. Workloads are successfully replicated to new profile namespaces