### PR TITLE
cherry-pick: Support functionality to override default images for kfp-profile-controller

### DIFF
--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  custom_images:
+    type: string
+    default: | 
+      visualization_server : ''
+      frontend_image : ''
+    description: >
+      YAML or JSON formatted input defining images to use in Katib
+      For usage details, see https://github.com/canonical/kfp-operators.

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -23,6 +23,10 @@ class KfpProfileControllerInputs:
     CONTROLLER_PORT: int
     METADATA_GRPC_SERVICE_HOST: str
     METADATA_GRPC_SERVICE_PORT: str
+    VISUALIZATION_SERVER_IMAGE: str
+    VISUALIZATION_SERVER_TAG: str
+    FRONTEND_IMAGE: str
+    FRONTEND_TAG: str
 
 
 class KfpProfileControllerPebbleService(PebbleServiceComponent):
@@ -61,6 +65,10 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                             "CONTROLLER_PORT": inputs.CONTROLLER_PORT,
                             "METADATA_GRPC_SERVICE_HOST": inputs.METADATA_GRPC_SERVICE_HOST,
                             "METADATA_GRPC_SERVICE_PORT": inputs.METADATA_GRPC_SERVICE_PORT,
+                            "VISUALIZATION_SERVER_IMAGE": inputs.VISUALIZATION_SERVER_IMAGE,
+                            "VISUALIZATION_SERVER_TAG": inputs.VISUALIZATION_SERVER_TAG,
+                            "FRONTEND_IMAGE": inputs.FRONTEND_IMAGE,
+                            "FRONTEND_TAG": inputs.FRONTEND_TAG,
                         },
                     }
                 }

--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,0 +1,4 @@
+{
+    "visualization_server": "gcr.io/ml-pipeline/visualization-server:2.0.3",
+    "frontend": "gcr.io/ml-pipeline/frontend:2.0.3"
+}

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
 from base64 import b64decode
 from pathlib import Path
@@ -19,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
+
+CUSTOM_FRONTEND_IMAGE = "gcr.io/ml-pipeline/frontend:latest"
+CUSTOM_VISUALISATION_IMAGE = "gcr.io/ml-pipeline/visualization-server:latest"
+
 PodDefault = create_namespaced_resource(
     group="kubeflow.org", version="v1alpha1", kind="PodDefault", plural="poddefaults"
 )
@@ -172,6 +177,34 @@ def validate_profile_resources(
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
 
+@retry(
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    stop=stop_after_delay(30),
+    reraise=True,
+)
+def validate_profile_deployments_with_custom_images(
+    lightkube_client: lightkube.Client,
+    profile_name: str,
+    frontend_image: str,
+    visualisation_image: str,
+):
+    """Tests if profile's deployment have correct images"""
+    # Get deployments
+    pipeline_ui_deployment = lightkube_client.get(
+        Deployment, name="ml-pipeline-ui-artifact", namespace=profile_name
+    )
+    visualization_server_deployment = lightkube_client.get(
+        Deployment, name="ml-pipeline-visualizationserver", namespace=profile_name
+    )
+
+    # Assert images
+    assert pipeline_ui_deployment.spec.template.spec.containers[0].image == frontend_image
+    assert (
+        visualization_server_deployment.spec.template.spec.containers[0].image
+        == visualisation_image
+    )
+
+
 async def test_model_resources(ops_test: OpsTest):
     """Tests if the resources associated with secret's namespace were created.
 
@@ -225,3 +258,24 @@ async def test_sync_webhook(lightkube_client: lightkube.Client, profile: str):
     ]
     for resource, name in desired_resources:
         lightkube_client.get(resource, name=name, namespace=profile)
+
+
+async def test_change_custom_images(
+    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
+):
+    """Tests that updating images deployed to user Namespaces works as expected."""
+    custom_images = {
+        "visualization_server": CUSTOM_VISUALISATION_IMAGE,
+        "frontend": CUSTOM_FRONTEND_IMAGE,
+    }
+    await ops_test.model.applications[CHARM_NAME].set_config(
+        {"custom_images": json.dumps(custom_images)}
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[CHARM_NAME], status="active", raise_on_blocked=True, timeout=300
+    )
+
+    validate_profile_deployments_with_custom_images(
+        lightkube_client, profile, CUSTOM_FRONTEND_IMAGE, CUSTOM_VISUALISATION_IMAGE
+    )

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -39,6 +39,10 @@ EXPECTED_ENVIRONMENT = {
     "MINIO_NAMESPACE": MOCK_OBJECT_STORAGE_DATA["namespace"],
     "MINIO_PORT": MOCK_OBJECT_STORAGE_DATA["port"],
     "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
+    "FRONTEND_IMAGE": "gcr.io/ml-pipeline/frontend",
+    "FRONTEND_TAG": KFP_IMAGES_VERSION,
+    "VISUALIZATION_SERVER_IMAGE": "gcr.io/ml-pipeline/visualization-server",
+    "VISUALIZATION_SERVER_TAG": KFP_IMAGES_VERSION,
 }
 
 


### PR DESCRIPTION
cherry-picks into `track/2.0`:
Support functionality to override default images for kfp-profile-controller (#416)

Fixing as part of the effort to test CKF 1.8 in airgapped, see https://github.com/canonical/bundle-kubeflow/issues/889.