### PR TITLE
fix: set correct default for custom_images in kfp-profile-controller

### DIFF
--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -4,9 +4,10 @@
 options:
   custom_images:
     type: string
+    # defaults should match src/defaults-custom-images.json
     default: | 
       visualization_server : ''
-      frontend_image : ''
+      frontend : ''
     description: >
       YAML or JSON formatted input defining images to use in Katib
       For usage details, see https://github.com/canonical/kfp-operators.


### PR DESCRIPTION
closes #484 

## Summary
The default of `custom_images` config in `kfp-profile-controller` charm says `frontend_image` whereas the actual key you should set is just `frontend` as defined in the `.json`

It is currently misleading to users and will cause them to set the config incorrectly, which will then not take effect as expected.

This PR sets the config default to the correct `frontend` value.