### PR TITLE
fix: handle incorrect custom images config

### DIFF
--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -245,11 +245,12 @@ class KfpProfileControllerOperator(CharmBase):
                     images[image_name] = custom_image
                 else:
                     logger.error(
-                        f"Image name `{image_name}` set in `custom_images` config not found in images list: {', '.join(images.keys())}."  # noqa E501
+                        f"Image name `{image_name}` set in `custom_images` config not found in "
+                        f"images list: {', '.join(images.keys())}."
                     )
                     raise ErrorWithStatus(
-                        "Incorrect image name in `custom_images` config - fix `custom_images` to unblock.  "  # noqa E501
-                        "See logs for more details",
+                        "Incorrect image name in `custom_images` config - fix `custom_images` to "
+                        "unblock.  See logs for more details",
                         BlockedStatus,
                     )
 


### PR DESCRIPTION
closes #485

## Summary
Fixes the error handling for setting the `custom_images` config in `kfp-profile-controller` charm
* refactors error handling when the `custom_images` config input has incorrect image name
* refactors error handling when the `custom_images` config input is an invalid yaml
* adds unit test for the 2 cases in the above points