### PR TITLE
ci: bootstrap juju controller with agent version 3.5.0 (#499)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -93,6 +93,8 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           juju-channel: 3.5/stable
+          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
+          bootstrap-options: "--agent-version=3.5.0"
           charmcraft-channel: latest/candidate
 
       - name: Integration tests
@@ -133,6 +135,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
+          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
+          bootstrap-options: "--agent-version=3.5.0"
           juju-channel: 3.5/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"


### PR DESCRIPTION
This commit ensures the controller is bootstrapped with version 3.5.0 instead of the default as we have found issues with it.
This is a workaround for canonical/bundle-kubeflow#921.

Fixes #498