### PR TITLE
fix: Update KFP Controller Python image to Ubuntu/python rock

### DIFF
--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image for kfp-profile-controller
-    upstream-source: python:3.11.9-alpine
+    upstream-source: ubuntu/python:3.8-20.04_stable
   # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
 requires:
   object-storage:

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -51,7 +51,9 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                     self.service_name: {
                         "override": "replace",
                         "summary": "entry point for kfp-profile-controller",
-                        "command": "python /hooks/sync.py",  # Must be a string
+                        # Upstream uses `python` instead of python3. We modified it in order
+                        # to be able to use ubuntu/python3.8 image.
+                        "command": "python3 /hooks/sync.py",  # Must be a string
                         "startup": "enabled",
                         "environment": {
                             "MINIO_HOST": inputs.MINIO_HOST,


### PR DESCRIPTION
Update the image to a Canonical maintained ROCK in order to fix #487 and
reduce the number of CVEs.

#### Testing
```bash
juju deploy metacontroller-operator --channel 3.0/stable --trust
juju deploy minio --channel ckf-1.8/stable
juju deploy kfp-profile-controller --channel 2.0/stable --trust --base ubuntu@20.04
juju relate kfp-profile-controller minio
juju status --watch 1s
# take a look at juju status or logs of kfp-profile-controller and verify that the issue's status and logs are there
# then refresh to this PR's
juju refresh kfp-profile-controller --channel 2.0/edge/pr-501
# verify that the workload starts and charm goes to `active`
kubectl -n <namespace> logs kfp-profile-controller-0 -c kfp-profile-controller | grep -i executable
```

Closes #487