### PR TITLE
Reverting to use 8.0/stable for mysql-k8s

### DIFF
--- a/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
@@ -23,8 +23,8 @@ applications:
       default-gateway: kubeflow-gateway
     trust: true
   kfp-db:
-    charm: mysql-k8s # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
-    channel: 8.0/edge
+    charm: mysql-k8s
+    channel: 8.0/stable
     scale: 1
     options:
       profile: testing

--- a/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
@@ -4,7 +4,6 @@ applications:
   argo-controller:         { charm: ch:argo-controller, channel: 3.3.10/stable, scale: 1, trust: true }
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: 3.0/stable, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: ckf-1.8/stable,       scale: 1 }
-  # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
   kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
   mlmd:                    { charm: ch:mlmd, channel: 1.14/stable, scale: 1 }
   envoy:                   { charm: ch:envoy, channel: 2.0/stable, scale: 1 }

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -4,9 +4,8 @@ applications:
   argo-controller:         { charm: ch:argo-controller, channel: latest/edge, scale: 1, trust: true }
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: latest/edge,       scale: 1 }
-  # We should use `8.0/stable` once changes for https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
-  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/edge, scale: 1, constraints: mem=2G, trust: true }
-  mlmd:                    { charm: ch:mlmd, channel: latest/edge, scale: 1 }
+  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
+  mlmd:                    { charm: ch:mlmd, channel: latest/edge, scale: 1}
   envoy:                   { charm: ch:envoy, channel: latest/edge, scale: 1 }
   kubeflow-profiles:       { charm: ch:kubeflow-profiles, channel: latest/edge, scale: 1, trust: true }
   istio-ingressgateway:


### PR DESCRIPTION
Since the the issue [1] was merged and those changes are already in 8.0/stable we can use that channel again.

fixes: #401

---
[1]: https://github.com/canonical/mysql-k8s-operator/issues/337