### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track 2.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -92,9 +92,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.5/stable
-          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
-          bootstrap-options: "--agent-version=3.5.0"
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
 
       - name: Integration tests
@@ -135,9 +133,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
-          bootstrap-options: "--agent-version=3.5.0"
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944