### PR TITLE
Cherry pick: Fix recurring runs

### DIFF
--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -73,7 +73,6 @@ class KfpSchedwf(CharmBase):
                 container_name="ml-pipeline-scheduledworkflow",
                 service_name="controller",
                 timezone=self.model.config["timezone"],
-                log_level=self.model.config["log-level"],
             ),
             depends_on=[self.kubernetes_resources],
         )

--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -73,7 +73,11 @@ class KfpSchedwf(CharmBase):
                 container_name="ml-pipeline-scheduledworkflow",
                 service_name="controller",
                 timezone=self.model.config["timezone"],
+<<<<<<< HEAD
                 namespace=self.model.name,
+=======
+                log_level=self.model.config["log-level"],
+>>>>>>> 915111a (Remove the namespace field in the pebble class)
             ),
             depends_on=[self.kubernetes_resources],
         )

--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -73,11 +73,7 @@ class KfpSchedwf(CharmBase):
                 container_name="ml-pipeline-scheduledworkflow",
                 service_name="controller",
                 timezone=self.model.config["timezone"],
-<<<<<<< HEAD
-                namespace=self.model.name,
-=======
                 log_level=self.model.config["log-level"],
->>>>>>> 915111a (Remove the namespace field in the pebble class)
             ),
             depends_on=[self.kubernetes_resources],
         )

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -24,7 +24,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self.environment = {
             "CRON_SCHEDULE_TIMEZONE": timezone,
             "LOG_LEVEL": log_level,
-            "NAMESPACE": ""
+            "NAMESPACE": "",
         }
 >>>>>>> b94f628 (Change namespace in kfp-schedwf)
         self.namespace = namespace

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -13,15 +13,12 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self,
         *args,
         timezone: str,
-        log_level: str,
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
         super().__init__(*args, **kwargs)
-        self.environment = {"CRON_SCHEDULE_TIMEZONE": timezone}
         self.environment = {
             "CRON_SCHEDULE_TIMEZONE": timezone,
-            "LOG_LEVEL": log_level,
             "NAMESPACE": "",
         }
 

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -13,7 +13,11 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self,
         *args,
         timezone: str,
+<<<<<<< HEAD
         namespace: str,
+=======
+        log_level: str,
+>>>>>>> 915111a (Remove the namespace field in the pebble class)
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
@@ -26,8 +30,11 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
             "LOG_LEVEL": log_level,
             "NAMESPACE": "",
         }
+<<<<<<< HEAD
 >>>>>>> b94f628 (Change namespace in kfp-schedwf)
         self.namespace = namespace
+=======
+>>>>>>> 915111a (Remove the namespace field in the pebble class)
 
     def get_layer(self) -> Layer:
         """Defines and returns Pebble layer configuration

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -13,28 +13,17 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self,
         *args,
         timezone: str,
-<<<<<<< HEAD
-        namespace: str,
-=======
         log_level: str,
->>>>>>> 915111a (Remove the namespace field in the pebble class)
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
         super().__init__(*args, **kwargs)
-<<<<<<< HEAD
         self.environment = {"CRON_SCHEDULE_TIMEZONE": timezone}
-=======
         self.environment = {
             "CRON_SCHEDULE_TIMEZONE": timezone,
             "LOG_LEVEL": log_level,
             "NAMESPACE": "",
         }
-<<<<<<< HEAD
->>>>>>> b94f628 (Change namespace in kfp-schedwf)
-        self.namespace = namespace
-=======
->>>>>>> 915111a (Remove the namespace field in the pebble class)
 
     def get_layer(self) -> Layer:
         """Defines and returns Pebble layer configuration

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -56,8 +56,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         "override": "replace",
                         "summary": "scheduled workflow controller service",
                         "startup": "enabled",
-                        "command": "/bin/controller --logtostderr=true"
-                        ' --namespace=""',
+                        "command": "/bin/controller --logtostderr=true" ' --namespace=""',
                         "environment": self.environment,
                     }
                 },

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -18,7 +18,15 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
     ):
         """Pebble service container component in order to configure Pebble layer"""
         super().__init__(*args, **kwargs)
+<<<<<<< HEAD
         self.environment = {"CRON_SCHEDULE_TIMEZONE": timezone}
+=======
+        self.environment = {
+            "CRON_SCHEDULE_TIMEZONE": timezone,
+            "LOG_LEVEL": log_level,
+            "NAMESPACE": ""
+        }
+>>>>>>> b94f628 (Change namespace in kfp-schedwf)
         self.namespace = namespace
 
     def get_layer(self) -> Layer:
@@ -42,7 +50,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         "summary": "scheduled workflow controller service",
                         "startup": "enabled",
                         "command": "/bin/controller --logtostderr=true"
-                        " --namespace={self.namespace}",
+                        ' --namespace=""',
                         "environment": self.environment,
                     }
                 },


### PR DESCRIPTION
Cherry-pick that closes #517 

This PR updates the pebble_components.py file in the kfp-schedwf charm to use a different namespace, similar to the one in [upstream](https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.scheduledworkflow#L49). Also removes the `namespace` field in the relevant Pebble class.