### PR TITLE
fix: watch for recurring runs in the correct namespace and expand integration tests for recurring runs

### DIFF
--- a/charms/kfp-schedwf/src/charm.py
+++ b/charms/kfp-schedwf/src/charm.py
@@ -75,7 +75,6 @@ class KfpSchedwf(CharmBase):
                 service_name="controller",
                 timezone=self.model.config["timezone"],
                 log_level=self.model.config["log-level"],
-                namespace="",
             ),
             depends_on=[self.kubernetes_resources],
         )

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -14,7 +14,6 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         *args,
         timezone: str,
         log_level: str,
-        namespace: str,
         **kwargs,
     ):
         """Pebble service container component in order to configure Pebble layer"""
@@ -22,8 +21,8 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
         self.environment = {
             "CRON_SCHEDULE_TIMEZONE": timezone,
             "LOG_LEVEL": log_level,
+            "NAMESPACE:": "",
         }
-        self.namespace = namespace
         self.log_level = log_level
 
     def get_layer(self) -> Layer:
@@ -47,7 +46,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         "summary": "scheduled workflow controller service",
                         "startup": "enabled",
                         "command": f"/bin/controller --logtostderr=true"
-                        f" --namespace={self.namespace}"
+                        ' --namespace=""'
                         f" --logLevel={self.log_level}",
                         "environment": self.environment,
                     }

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -45,7 +45,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         "override": "replace",
                         "summary": "scheduled workflow controller service",
                         "startup": "enabled",
-                        "command": f"/bin/controller --logtostderr=true"
+                        "command": "/bin/controller --logtostderr=true"
                         ' --namespace=""'
                         f" --logLevel={self.log_level}",
                         "environment": self.environment,

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -188,7 +188,18 @@ async def test_create_and_monitor_recurring_run(
     assert recurring_job.trigger.cron_schedule.cron == "*/2 * * * * *"
 
     # Wait for the recurring job to schedule some runs
-    time.sleep(6)
+    time.sleep(20)
+
+    first_run = kfp_client.list_runs(experiment_id=experiment_response.experiment_id,
+                                          namespace=KUBEFLOW_PROFILE_NAMESPACE).runs[0]
+
+    # Assert that a run has been created from the recurring job
+    assert first_run.recurring_run_id == recurring_job.recurring_run_id
+
+    # Monitor the run to completion, the pipeline should not be executed in
+    # more than 300 seconds as it is a very simple operation
+    monitor_response = kfp_client.wait_for_run_completion(first_run.run_id, timeout=600)
+    assert monitor_response.state == "SUCCEEDED"
 
     # FIXME: disabling the job does not work at the moment, it seems like
     # the status of the recurring run is never updated and is causing the


### PR DESCRIPTION
Closes #517 

This PR updates the kfp-schedwf charm to use an empty namespace, similar to the one in [upstream](https://github.com/kubeflow/pipelines/blob/2.0.5/backend/Dockerfile.scheduledworkflow#L49).

Also, the `create_and_monitor_recurring_run` test is expanded to actually test that the run has been created and finished successfully.