### PR TITLE
fix: remove deprecated prime part from charmcraft.yaml file

### DIFF
--- a/charms/kfp-profile-controller/charmcraft.yaml
+++ b/charms/kfp-profile-controller/charmcraft.yaml
@@ -9,9 +9,12 @@ bases:
     - name: "ubuntu"
       channel: "20.04"
 parts:
-  charm:
+  scripts:
+    plugin: dump
+    source: "."
     prime:
-      - ./files/upstream/sync.py
+      - files/upstream/sync.py
+  charm:
     charm-python-packages: [setuptools, pip]  # Fixes install of some packages
     # Install jinja2 (a dependency of charmed-kubeflow-chisme) from binary to avoid build-time issues
     # See https://github.com/canonical/bundle-kubeflow/issues/883


### PR DESCRIPTION
Remove the prime key from the charm part and instead move it to its dedicated scripts part to generate a valid charm.
The prime key has been deprecated and charmcraft 3.x and will no longer build valid charms that can be deployed.

For details about the fix, please refer to the issue.

Fixes #544