### PR TITLE
ci: bump python-libjuju 3.2.x -> 3.5.x

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -10,6 +10,8 @@ aiosignal==1.3.1
     # via aiohttp
 anyio==4.0.0
     # via httpcore
+appnope==0.1.4
+    # via ipython
 asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3
@@ -84,7 +86,7 @@ jinja2==3.1.2
     # via pytest-operator
 jsonschema==4.17.3
     # via -r requirements-integration.in
-juju==3.2.2
+juju==3.5.2.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -109,7 +111,9 @@ mypy-extensions==1.0.0
 oauthlib==3.2.2
     # via requests-oauthlib
 packaging==23.1
-    # via pytest
+    # via
+    #   juju
+    #   pytest
 paramiko==2.12.0
     # via juju
 parso==0.8.3

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -10,8 +10,6 @@ aiosignal==1.3.1
     # via aiohttp
 anyio==4.0.0
     # via httpcore
-appnope==0.1.4
-    # via ipython
 asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3


### PR DESCRIPTION
This change prevents juju from disconnecting and keeps compatibility with the latest `juju` agent used in the CI.