### PR TITLE
fix: increase juju MAX_FRAME_SIZE to avoid reconnection issues

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -133,6 +133,19 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+    - name: Setup Charmcraft's pip cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/snap/charmcraft/common/cache/charmcraft/
+        # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
+        # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
+        # "first" match, which will be from the most recent run.  
+        # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
+        restore-keys: craft-shared-cache
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -92,6 +92,19 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Setup Charmcraft's pip cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft/
+          # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
+          # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
+          # "first" match, which will be from the most recent run.  
+          # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+          key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}-individual-test-$${{ matrix.charm }}
+          restore-keys: craft-shared-cache
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -143,7 +156,7 @@ jobs:
           # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
           # "first" match, which will be from the most recent run.  
           # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-          key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
+          key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}-test-bundle
           restore-keys: craft-shared-cache
 
       - name: Setup operator environment

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -133,18 +133,18 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-    - name: Setup Charmcraft's pip cache
-      id: cache
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/snap/charmcraft/common/cache/charmcraft/
-        # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
-        # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-        # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
-        # "first" match, which will be from the most recent run.  
-        # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
-        restore-keys: craft-shared-cache
+      - name: Setup Charmcraft's pip cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft/
+          # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
+          # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
+          # "first" match, which will be from the most recent run.  
+          # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+          key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
+          restore-keys: craft-shared-cache
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,7 +29,6 @@ PROFILE_FILE_PATH = f"{basedir}/tests/integration/profile/profile.yaml"
 PROFILE_FILE = yaml.safe_load(Path(PROFILE_FILE_PATH).read_text())
 KUBEFLOW_USER_NAME = PROFILE_FILE["spec"]["owner"]["name"]
 
-
 @pytest.fixture(scope="session")
 def forward_kfp_ui():
     """Port forward the kfp-ui service."""

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -18,6 +18,7 @@ from kfp_globals import (
     SAMPLE_VIEWER,
 )
 
+import juju
 import json
 import kfp
 import lightkube
@@ -29,7 +30,9 @@ from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.apps_v1 import Deployment
 from pytest_operator.plugin import OpsTest
 
+juju.client.connection.Connection.MAX_FRAME_SIZE = 2**32
 KFP_SDK_VERSION = "v2"
+
 log = logging.getLogger(__name__)
 
 

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -239,13 +239,9 @@ async def test_apply_sample_viewer(lightkube_client):
 
 async def test_viz_server_healthcheck(ops_test: OpsTest):
     """Run a healthcheck on the server endpoint."""
-    # This is a workaround for canonical/kfp-operators#549
-    # Leave model=kubeflow as this test case
-    # should always be executed on that model
-    juju_status = sh.juju.status(format="json", no_color=True, model="kubeflow")
-    kfp_viz_unit = json.loads(juju_status)["applications"]["kfp-viz"]["units"]["kfp-viz/0"]
-    url = kfp_viz_unit["address"]
-
+    status = await ops_test.model.get_status()
+    units = status["applications"]["kfp-viz"]["units"]
+    url = units["kfp-viz/0"]["address"]
     headers = {"kubeflow-userid": "user"}
     result_status, result_text = await fetch_response(url=f"http://{url}:8888", headers=headers)
 


### PR DESCRIPTION
Increase Juju websocket connection MAX_FRAME_SIZE to 1024MiB to avoid RPC: Connection closed, reconnecting errors during integration test executions.

Part of #549