### PR TITLE
Update tools/get-images.sh to handle both Go and Python versions of yq

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -3,6 +3,9 @@
 # This script returns list of container images that are managed by this charm and/or its workload
 #
 # dynamic list
+
+set -xe
+
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \; | tr -d '"'))
 IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options | with_entries(select(.key | test("-image$"))) | .[].default' {} \; | tr -d '"'))

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -4,6 +4,6 @@
 #
 # dynamic list
 IMAGE_LIST=()
-IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
-IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options.*-image |  select(.) | .default' {} \;))
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \; | tr -d '"'))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options | with_entries(select(.key | test("-image$"))) | .[].default' {} \; | tr -d '"'))
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Closes #562

This PR updates `tools/get-images.sh` to be version agnostic when it comes to the `yq` utility. There is additional context in the [issue's description](https://github.com/canonical/kfp-operators/issues/562#issue-2492407938).

From experimentation, the Python version of `yq` also adds quotes to the output, so `tr` is called to remove any quote characters from all the entries.

To test:
- Run `bash tools/get-images.sh` with the snap version of `yq` (installed via `sudo snap install yq`)
- Run `bash tools/get-images.sh` with the Python verison of `yq` (installed via `pip install yq`)
- The output should be the same, and the same as when running `bash tools/get-images.sh` in the `main` branch.