### PR TITLE
(backport) Feat: Add Terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -66,6 +66,27 @@ jobs:
       - run: python3 -m pip install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    strategy:
+      matrix:
+        charm:
+          - kfp-api
+          - kfp-metadata-writer
+          - kfp-persistence
+          - kfp-profile-controller
+          - kfp-schedwf
+          - kfp-ui
+          - kfp-viewer
+          - kfp-viz
+    with:
+      charm-path: ./charms/${{ matrix.charm }}
+      # The namespace is hardcoded in the upstream project
+      # So the model's name must be kubeflow
+      # See: https://github.com/kubeflow/kubeflow/issues/6136
+      model: kubeflow
+        
   integration:
     name: Integration tests (microk8s)
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -82,6 +82,7 @@ jobs:
           - kfp-viz
     with:
       charm-path: ./charms/${{ matrix.charm }}
+      channel: "2.2/stable"
       # The namespace is hardcoded in the upstream project
       # So the model's name must be kubeflow
       # See: https://github.com/kubeflow/kubeflow/issues/6136

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .idea
 .vscode
 venv
+.terraform*
+*.tfstate*

--- a/charms/kfp-api/terraform/README.md
+++ b/charms/kfp-api/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for kfp-api
+
+This is a Terraform module facilitating the deployment of the kfp-api charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-api" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-api" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-api/terraform/main.tf
+++ b/charms/kfp-api/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_api" {
+  charm {
+    name     = "kfp-api"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-api/terraform/outputs.tf
+++ b/charms/kfp-api/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "app_name" {
+  value = juju_application.kfp_api.name
+}
+
+output "provides" {
+  value = {
+    kfp_api           = "kfp-api",
+    metrics_endpoint  = "metrics-endpoint",
+    grafana_dashboard = "grafana-dashboard",
+  }
+}
+
+output "requires" {
+  value = {
+    mysql          = "mysql",
+    relational_db  = "relational-db",
+    object_storage = "object-storage",
+    kfp_viz        = "kfp-viz",
+    logging        = "logging",
+  }
+}

--- a/charms/kfp-api/terraform/variables.tf
+++ b/charms/kfp-api/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-api/terraform/variables.tf
+++ b/charms/kfp-api/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-api"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-api/terraform/versions.tf
+++ b/charms/kfp-api/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-api/tox.ini
+++ b/charms/kfp-api/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-metadata-writer/terraform/README.md
+++ b/charms/kfp-metadata-writer/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-metadata-writer
+
+This is a Terraform module facilitating the deployment of the kfp-metadata-writer charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-metadata-writer" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-metadata-writer" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-metadata-writer/terraform/main.tf
+++ b/charms/kfp-metadata-writer/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_metadata_writer" {
+  charm {
+    name     = "kfp-metadata-writer"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-metadata-writer/terraform/outputs.tf
+++ b/charms/kfp-metadata-writer/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "app_name" {
+  value = juju_application.kfp_metadata_writer.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    grpc    = "grpc",
+    logging = "logging"
+  }
+}

--- a/charms/kfp-metadata-writer/terraform/variables.tf
+++ b/charms/kfp-metadata-writer/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-metadata-writer/terraform/variables.tf
+++ b/charms/kfp-metadata-writer/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-metadata-writer"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-metadata-writer/terraform/versions.tf
+++ b/charms/kfp-metadata-writer/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-metadata-writer/tox.ini
+++ b/charms/kfp-metadata-writer/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-persistence/terraform/README.md
+++ b/charms/kfp-persistence/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-persistence
+
+This is a Terraform module facilitating the deployment of the kfp-persistence charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-persistence" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-persistence" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-persistence/terraform/main.tf
+++ b/charms/kfp-persistence/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_persistence" {
+  charm {
+    name     = "kfp-persistence"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-persistence/terraform/outputs.tf
+++ b/charms/kfp-persistence/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "app_name" {
+  value = juju_application.kfp_persistence.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    kfp_api = "kfp-api",
+    logging = "logging"
+  }
+}

--- a/charms/kfp-persistence/terraform/variables.tf
+++ b/charms/kfp-persistence/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-persistence/terraform/variables.tf
+++ b/charms/kfp-persistence/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-persistence"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-persistence/terraform/versions.tf
+++ b/charms/kfp-persistence/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-persistence/tox.ini
+++ b/charms/kfp-persistence/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-profile-controller/terraform/README.md
+++ b/charms/kfp-profile-controller/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-profile-controller
+
+This is a Terraform module facilitating the deployment of the kfp-profile-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-profile-controller" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-profile-controller" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-profile-controller/terraform/main.tf
+++ b/charms/kfp-profile-controller/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_profile_controller" {
+  charm {
+    name     = "kfp-profile-controller"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-profile-controller/terraform/outputs.tf
+++ b/charms/kfp-profile-controller/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "app_name" {
+  value = juju_application.kfp_profile_controller.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    object_storage = "object-storage",
+    logging        = "logging",
+  }
+}

--- a/charms/kfp-profile-controller/terraform/variables.tf
+++ b/charms/kfp-profile-controller/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-profile-controller/terraform/variables.tf
+++ b/charms/kfp-profile-controller/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-profile-controller"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-profile-controller/terraform/versions.tf
+++ b/charms/kfp-profile-controller/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-profile-controller/tox.ini
+++ b/charms/kfp-profile-controller/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-schedwf/terraform/README.md
+++ b/charms/kfp-schedwf/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-schedwf
+
+This is a Terraform module facilitating the deployment of the kfp-schedwf charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-schedwf" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-schedwf" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-schedwf/terraform/main.tf
+++ b/charms/kfp-schedwf/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_schedwf" {
+  charm {
+    name     = "kfp-schedwf"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-schedwf/terraform/outputs.tf
+++ b/charms/kfp-schedwf/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "app_name" {
+  value = juju_application.kfp_schedwf.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    logging = "logging"
+  }
+}

--- a/charms/kfp-schedwf/terraform/variables.tf
+++ b/charms/kfp-schedwf/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-schedwf/terraform/variables.tf
+++ b/charms/kfp-schedwf/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-schedwf"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-schedwf/terraform/versions.tf
+++ b/charms/kfp-schedwf/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-schedwf/tox.ini
+++ b/charms/kfp-schedwf/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-ui/terraform/README.md
+++ b/charms/kfp-ui/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-ui
+
+This is a Terraform module facilitating the deployment of the kfp-ui charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-ui" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-ui" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-ui/terraform/main.tf
+++ b/charms/kfp-ui/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_ui" {
+  charm {
+    name     = "kfp-ui"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-ui/terraform/outputs.tf
+++ b/charms/kfp-ui/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "app_name" {
+  value = juju_application.kfp_ui.name
+}
+
+output "provides" {
+  value = {
+    kfp_ui = "kfp-ui"
+  }
+}
+
+output "requires" {
+  value = {
+    object_storage  = "object-storage",
+    kfp_api         = "kfp-api",
+    ingress         = "ingress",
+    dashboard_links = "dashboard-links",
+    logging         = "logging"
+  }
+}

--- a/charms/kfp-ui/terraform/variables.tf
+++ b/charms/kfp-ui/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-ui/terraform/variables.tf
+++ b/charms/kfp-ui/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-ui"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-ui/terraform/versions.tf
+++ b/charms/kfp-ui/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-ui/tox.ini
+++ b/charms/kfp-ui/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-viewer/terraform/README.md
+++ b/charms/kfp-viewer/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-viewer
+
+This is a Terraform module facilitating the deployment of the kfp-viewer charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-viewer" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-viewer" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-viewer/terraform/main.tf
+++ b/charms/kfp-viewer/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_viewer" {
+  charm {
+    name     = "kfp-viewer"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-viewer/terraform/outputs.tf
+++ b/charms/kfp-viewer/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "app_name" {
+  value = juju_application.kfp_viewer.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    logging = "logging"
+  }
+}

--- a/charms/kfp-viewer/terraform/variables.tf
+++ b/charms/kfp-viewer/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-viewer/terraform/variables.tf
+++ b/charms/kfp-viewer/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-viewer"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-viewer/terraform/versions.tf
+++ b/charms/kfp-viewer/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-viewer/tox.ini
+++ b/charms/kfp-viewer/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/kfp-viz/terraform/README.md
+++ b/charms/kfp-viz/terraform/README.md
@@ -1,0 +1,57 @@
+# Terraform module for kfp-viz
+
+This is a Terraform module facilitating the deployment of the kfp-viz charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kfp-viz" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kfp-viz" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kfp-viz/terraform/main.tf
+++ b/charms/kfp-viz/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kfp_viz" {
+  charm {
+    name     = "kfp-viz"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kfp-viz/terraform/outputs.tf
+++ b/charms/kfp-viz/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "app_name" {
+  value = juju_application.kfp_viz.name
+}
+
+output "provides" {
+  value = {
+    kfp_viz = "kfp-viz"
+  }
+}
+
+output "requires" {
+  value = {
+    logging = "logging"
+  }
+}

--- a/charms/kfp-viz/terraform/variables.tf
+++ b/charms/kfp-viz/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.2/stable"
 }
 
 variable "config" {

--- a/charms/kfp-viz/terraform/variables.tf
+++ b/charms/kfp-viz/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kfp-viz"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kfp-viz/terraform/versions.tf
+++ b/charms/kfp-viz/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kfp-viz/tox.ini
+++ b/charms/kfp-viz/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Ref #570.

This PR is a backport and creates a `terraform/` directory in each charm that hosts the Terraform module. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit).

To test the module:
- Clone the repository and switch to this branch.
- First run `tox -e tflint` to ensure that linting is correct
- Change to the `terraform/` directory and run `terraform init`.
- Run `terraform apply -var "channel=2.2/stable" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.