### PR TITLE
chore: Upgrade manifests to 2.3.0

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -51,13 +51,13 @@ options:
     description: Default name of object storage bucket.
   launcher-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/src/v2/compiler/argocompiler/container.go#L30
-    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:8fe5e6e4718f20b021736022ad3741ddf2abd82aa58c86ae13e89736fdc3f08f"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/src/v2/compiler/argocompiler/container.go#L33
+    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:bef55a344574a25c557256d7c66cb19edacfd2008d694e5b6bb5b612d59feae0"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.2.0/backend/src/v2/compiler/argocompiler/container.go#L32
-    default: "gcr.io/ml-pipeline/kfp-driver@sha256:3c0665cd36aa87e4359a4c8b6271dcba5bdd817815cd0496ed12eb5dde5fd2ec"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/src/v2/compiler/argocompiler/container.go#L35
+    default: "gcr.io/ml-pipeline/kfp-driver@sha256:dc8b56a2eb071f30409828a8884d621092e68385af11a6c06aa9e9fbcfbb19de"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/api-server:2.2.0-4d2f32c
+    upstream-source: gcr.io/ml-pipeline/api-server:2.3.0
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-api/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-api/src/templates/auth_manifests.yaml.j2
@@ -205,6 +205,7 @@ rules:
   - workflows/finalizers
   - workfloweventbindings
   - workflowtemplates
+  - workflowtaskresults
   verbs:
   - '*'
 ---

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: charmedkubeflow/metadata-writer:2.2.0-cff3205
+    upstream-source: gcr.io/ml-pipeline/metadata-writer:2.3.0
 requires:
   grpc:
     interface: k8s-service

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/persistenceagent:2.2.0-8af6d3c
+    upstream-source: gcr.io/ml-pipeline/persistenceagent:2.3.0
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/scheduledworkflow:2.2.0-517f00c
+    upstream-source: gcr.io/ml-pipeline/scheduledworkflow:2.3.0
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: gcr.io/ml-pipeline/frontend:2.2.0
+    upstream-source: gcr.io/ml-pipeline/frontend:2.3.0
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -219,6 +219,7 @@ class KfpUiOperator(CharmBase):
                 ],
                 inputs_getter=lambda: MlPipelineUiInputs(
                     ALLOW_CUSTOM_VISUALIZATIONS=self.model.config["allow-custom-visualizations"],
+                    FRONTEND_SERVER_NAMESPACE=self.model.name,
                     HIDE_SIDENAV=self.model.config["hide-sidenav"],
                     MINIO_ACCESS_KEY=self.object_storage_relation.component.get_data()[
                         "access-key"

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -12,6 +12,7 @@ class MlPipelineUiInputs:
     """Defines the required inputs for MlPipelineUiPebbleService."""
 
     ALLOW_CUSTOM_VISUALIZATIONS: bool
+    FRONTEND_SERVER_NAMESPACE: str
     HIDE_SIDENAV: bool
     MINIO_ACCESS_KEY: str
     MINIO_SECRET_KEY: str
@@ -61,6 +62,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "DISABLE_GKE_METADATA": "false",
                             "ENABLE_AUTHZ": "true",
                             "DEPLOYMENT": "KUBEFLOW",
+                            "FRONTEND_SERVER_NAMESPACE": inputs.FRONTEND_SERVER_NAMESPACE,
                             "HIDE_SIDENAV": str(inputs.HIDE_SIDENAV).lower(),
                             "HTTP_AUTHORIZATION_DEFAULT_VALUE": "",
                             "HTTP_AUTHORIZATION_KEY": "",

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: charmedkubeflow/viewer-crd-controller:2.2.0-aaa1d41
+    upstream-source: gcr.io/ml-pipeline/viewer-crd-controller:2.3.0
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: charmedkubeflow/visualization-server:2.2.0-d65cd0c
+    upstream-source: gcr.io/ml-pipeline/visualization-server:2.3.0
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
Upgrade manifests to 2.3.0. For producing the manifests, instructions in the [CONTRIBUTING.md](https://github.com/canonical/kfp-operators/blob/main/CONTRIBUTING.md) file were followed.

This includes:
* Upgrading images
* Updating kfp-api auth-manifests
* Introducing a new envvar in kfp-ui

Fixes #580

#### Tests
CI is fails mostly intermittently due to #602 and #601. Locally, they are successful (I hit #601 only once which looks unrelated to charms changes). I 've also refreshed a CKF deployment with the PR's charms and ran some pipelines, the kfp UAT and also enabled a recurring one.
