### PR TITLE
feat: add envs to ensure kfp-ui can show logs

### DIFF
--- a/charms/kfp-ui/config.yaml
+++ b/charms/kfp-ui/config.yaml
@@ -11,11 +11,6 @@ options:
     type: boolean
     default: true
     description: Enable Argo log archive
-  argo-key-format:
-    type: string
-    # Must have the same value as the default of `keyformat` config in `argo-controller` charm.
-    default: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
-    description: The keyFormat for pod logs artifacts stored
   disable-gke-metadata:
     type: boolean
     default: true

--- a/charms/kfp-ui/config.yaml
+++ b/charms/kfp-ui/config.yaml
@@ -11,6 +11,11 @@ options:
     type: boolean
     default: true
     description: Enable Argo log archive
+  argo-key-format:
+    type: string
+    # Must have the same value as the default of `keyformat` config in `argo-controller` charm.
+    default: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
+    description: The keyFormat for pod logs artifacts stored
   disable-gke-metadata:
     type: boolean
     default: true

--- a/charms/kfp-ui/config.yaml
+++ b/charms/kfp-ui/config.yaml
@@ -13,7 +13,7 @@ options:
     description: Enable Argo log archive
   argo-key-format:
     type: string
-    # Must have the same value as the default of `keyformat` config in `argo-controller` charm.
+    # Must have the same value as the default of `key-format` config in `argo-controller` charm.
     default: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
     description: The keyFormat for pod logs artifacts stored
   disable-gke-metadata:

--- a/charms/kfp-ui/config.yaml
+++ b/charms/kfp-ui/config.yaml
@@ -7,6 +7,14 @@ options:
     type: boolean
     default: true
     description: Allow custom visualizations
+  argo-archive-logs:
+    type: boolean
+    default: true
+    description: Enable Argo log archive
+  disable-gke-metadata:
+    type: boolean
+    default: true
+    description: Disable GKE metadata endpoint
   hide-sidenav:
     type: boolean
     default: true

--- a/charms/kfp-ui/config.yaml
+++ b/charms/kfp-ui/config.yaml
@@ -13,7 +13,7 @@ options:
     description: Enable Argo log archive
   argo-key-format:
     type: string
-    # Must have the same value as the default of `key-format` config in `argo-controller` charm.
+    # Must have the same value as the default of `keyformat` config in `argo-controller` charm.
     default: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
     description: The keyFormat for pod logs artifacts stored
   disable-gke-metadata:

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -219,6 +219,8 @@ class KfpUiOperator(CharmBase):
                 ],
                 inputs_getter=lambda: MlPipelineUiInputs(
                     ALLOW_CUSTOM_VISUALIZATIONS=self.model.config["allow-custom-visualizations"],
+                    ARGO_ARCHIVE_LOGS=self.model.config["argo-archive-logs"],
+                    DISABLE_GKE_METADATA=self.model.config["disable-gke-metadata"],
                     HIDE_SIDENAV=self.model.config["hide-sidenav"],
                     MINIO_ACCESS_KEY=self.object_storage_relation.component.get_data()[
                         "access-key"

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -220,6 +220,7 @@ class KfpUiOperator(CharmBase):
                 inputs_getter=lambda: MlPipelineUiInputs(
                     ALLOW_CUSTOM_VISUALIZATIONS=self.model.config["allow-custom-visualizations"],
                     ARGO_ARCHIVE_LOGS=self.model.config["argo-archive-logs"],
+                    ARGO_KEY_FORMAT=self.model.config["argo-key-format"],
                     DISABLE_GKE_METADATA=self.model.config["disable-gke-metadata"],
                     FRONTEND_SERVER_NAMESPACE=self.model.name,
                     HIDE_SIDENAV=self.model.config["hide-sidenav"],

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -220,7 +220,6 @@ class KfpUiOperator(CharmBase):
                 inputs_getter=lambda: MlPipelineUiInputs(
                     ALLOW_CUSTOM_VISUALIZATIONS=self.model.config["allow-custom-visualizations"],
                     ARGO_ARCHIVE_LOGS=self.model.config["argo-archive-logs"],
-                    ARGO_KEY_FORMAT=self.model.config["argo-key-format"],
                     DISABLE_GKE_METADATA=self.model.config["disable-gke-metadata"],
                     FRONTEND_SERVER_NAMESPACE=self.model.name,
                     HIDE_SIDENAV=self.model.config["hide-sidenav"],

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -54,6 +54,10 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
                             "ARGO_ARCHIVE_LOGS": inputs.ARGO_ARCHIVE_LOGS,
                             "ARGO_ARCHIVE_PREFIX": "logs",
+                            # Must have the same value as the `keyFormat` specified in the
+                            # `argo-workflow-controller-configmap` ConfigMap owned by
+                            # the `argo-controller` charm.
+                            "ARGO_KEYFORMAT": "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}",  # noqa E501
                             # TODO: This should come from relation to kfp-profile-controller.
                             #  It is the name/port of the user-specific artifact accessor
                             "ARTIFACTS_SERVICE_PROXY_NAME": "ml-pipeline-ui-artifact",

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -13,6 +13,7 @@ class MlPipelineUiInputs:
 
     ALLOW_CUSTOM_VISUALIZATIONS: bool
     ARGO_ARCHIVE_LOGS: bool
+    ARGO_KEY_FORMAT: str
     DISABLE_GKE_METADATA: bool
     FRONTEND_SERVER_NAMESPACE: str
     HIDE_SIDENAV: bool
@@ -54,10 +55,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
                             "ARGO_ARCHIVE_LOGS": inputs.ARGO_ARCHIVE_LOGS,
                             "ARGO_ARCHIVE_PREFIX": "logs",
-                            # Must have the same value as the `keyFormat` specified in the
-                            # `argo-workflow-controller-configmap` ConfigMap owned by
-                            # the `argo-controller` charm.
-                            "ARGO_KEYFORMAT": "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}",  # noqa E501
+                            "ARGO_KEYFORMAT": inputs.ARGO_KEY_FORMAT,
                             # TODO: This should come from relation to kfp-profile-controller.
                             #  It is the name/port of the user-specific artifact accessor
                             "ARTIFACTS_SERVICE_PROXY_NAME": "ml-pipeline-ui-artifact",

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -13,7 +13,6 @@ class MlPipelineUiInputs:
 
     ALLOW_CUSTOM_VISUALIZATIONS: bool
     ARGO_ARCHIVE_LOGS: bool
-    ARGO_KEY_FORMAT: str
     DISABLE_GKE_METADATA: bool
     FRONTEND_SERVER_NAMESPACE: str
     HIDE_SIDENAV: bool
@@ -55,7 +54,10 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
                             "ARGO_ARCHIVE_LOGS": inputs.ARGO_ARCHIVE_LOGS,
                             "ARGO_ARCHIVE_PREFIX": "logs",
-                            "ARGO_KEYFORMAT": inputs.ARGO_KEY_FORMAT,
+                            # Must have the same value as the `keyFormat` specified in the
+                            # `argo-workflow-controller-configmap` ConfigMap owned by
+                            # the `argo-controller` charm.
+                            "ARGO_KEYFORMAT": "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}",  # noqa E501
                             # TODO: This should come from relation to kfp-profile-controller.
                             #  It is the name/port of the user-specific artifact accessor
                             "ARTIFACTS_SERVICE_PROXY_NAME": "ml-pipeline-ui-artifact",

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -12,6 +12,8 @@ class MlPipelineUiInputs:
     """Defines the required inputs for MlPipelineUiPebbleService."""
 
     ALLOW_CUSTOM_VISUALIZATIONS: bool
+    ARGO_ARCHIVE_LOGS: bool
+    DISABLE_GKE_METADATA: bool
     HIDE_SIDENAV: bool
     MINIO_ACCESS_KEY: str
     MINIO_SECRET_KEY: str
@@ -49,7 +51,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             ).lower(),
                             "ARGO_ARCHIVE_ARTIFACTORY": "minio",
                             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
-                            "ARGO_ARCHIVE_LOGS": "false",
+                            "ARGO_ARCHIVE_LOGS": inputs.ARGO_ARCHIVE_LOGS,
                             "ARGO_ARCHIVE_PREFIX": "logs",
                             # TODO: This should come from relation to kfp-profile-controller.
                             #  It is the name/port of the user-specific artifact accessor
@@ -58,7 +60,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "ARTIFACTS_SERVICE_PROXY_ENABLED": "true",
                             "AWS_ACCESS_KEY_ID": "",
                             "AWS_SECRET_ACCESS_KEY": "",
-                            "DISABLE_GKE_METADATA": "false",
+                            "DISABLE_GKE_METADATA": inputs.DISABLE_GKE_METADATA,
                             "ENABLE_AUTHZ": "true",
                             "DEPLOYMENT": "KUBEFLOW",
                             "HIDE_SIDENAV": str(inputs.HIDE_SIDENAV).lower(),

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -56,7 +56,13 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             # Must have the same value as the `keyFormat` specified in the
                             # `argo-workflow-controller-configmap` ConfigMap owned by
                             # the `argo-controller` charm.
-                            "ARGO_KEYFORMAT": "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}",  # noqa E501
+                            "ARGO_KEYFORMAT": (
+                                "artifacts/{{workflow.name}}/"
+                                "{{workflow.creationTimestamp.Y}}/"
+                                "{{workflow.creationTimestamp.m}}/"
+                                "{{workflow.creationTimestamp.d}}/"
+                                "{{pod.name}}"
+                            ),
                             # TODO: This should come from relation to kfp-profile-controller.
                             #  It is the name/port of the user-specific artifact accessor
                             "ARTIFACTS_SERVICE_PROXY_NAME": "ml-pipeline-ui-artifact",

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -53,7 +53,6 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                             "ARGO_ARCHIVE_ARTIFACTORY": "minio",
                             "ARGO_ARCHIVE_BUCKETNAME": "mlpipeline",
                             "ARGO_ARCHIVE_LOGS": inputs.ARGO_ARCHIVE_LOGS,
-                            "ARGO_ARCHIVE_PREFIX": "logs",
                             # Must have the same value as the `keyFormat` specified in the
                             # `argo-workflow-controller-configmap` ConfigMap owned by
                             # the `argo-controller` charm.


### PR DESCRIPTION
Part of #582 

## Summary
Sets each of the following environment variables in `kfp-ui` to fix showing the logs after the workflow gets deleted:
* `ARGO_ARCHIVE_LOGS`
* `DISABLE_GKE_METADATA`
* `ARGO_KEYFORMAT`

Removes `ARGO_ARCHIVE_PREFIX` env var, as indicated by upstream in https://github.com/kubeflow/pipelines/pull/11010.

## Testing
For testing, see https://github.com/canonical/kfp-operators/issues/582#issuecomment-2500003055