### PR TITLE
fix(ci): Clean lxc instances on bundle integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -169,7 +169,7 @@ jobs:
         run: |
           # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
-          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2"
+          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --clean-lxc-instances
 
       - name: Get all
         run: kubectl get all -A

--- a/requirements-integration-v1.in
+++ b/requirements-integration-v1.in
@@ -11,3 +11,5 @@ pytest
 pytest-operator
 pyyaml
 tenacity
+sh
+jq

--- a/requirements-integration-v1.txt
+++ b/requirements-integration-v1.txt
@@ -130,6 +130,8 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via pytest-operator
+jq==1.8.0
+    # via -r requirements-integration-v1.in
 jsonschema==4.17.3
     # via
     #   -r requirements-integration-v1.in
@@ -272,6 +274,8 @@ rich==13.7.1
     # via typer
 rsa==4.9
     # via google-auth
+sh==2.1.0
+    # via -r requirements-integration-v1.in
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/requirements-integration-v2.in
+++ b/requirements-integration-v2.in
@@ -12,3 +12,4 @@ pytest-operator
 pyyaml
 sh
 tenacity
+jq

--- a/requirements-integration-v2.txt
+++ b/requirements-integration-v2.txt
@@ -109,6 +109,8 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via pytest-operator
+jq==1.8.0
+    # via -r requirements-integration-v2.in
 jsonschema==4.17.3
     # via -r requirements-integration-v2.in
 juju==3.5.2.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,7 @@ This directory has the following structure:
     │   ├── bundle_mgmt.py
     │   ├── k8s_resources.py
     │   └── localize_bundle.py
+    │   └── lxc.py
     ├── kfp_globals.py
     ├── pipelines/
     │   └── ... # Sample pipelines
@@ -57,10 +58,12 @@ Communication with the KFP API happens using the KFP Python SDK. A `kfp.client` 
 2. Run integration tests against the preferred bundle definition in `integration/bundles`
 
 ```
-tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> <--no-build>
+tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> <--no-build> <--clean-lxc-instances>
 ```
 
 Where,
 * `--model` tells the testing framework which model to deploy charms to
 * `--bundle` is the path to a bundle template that's going to be used during the test execution
 * `--no-build` tells the test suite whether to build charms and run tests against them, or use charms in Charmhub
+* `--no-build` tells the test suite whether to build charms and run tests against them, or use charms in Charmhub
+* `--clean-lxc-instances` tells the test suite whether to delete lxc instances after building and deploying the charms. If `--no-build` is passed, then this has no effect.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,3 +105,10 @@ def pytest_addoption(parser: Parser):
         "to render the bundle definition template."
         "If set to False, the integration tests will be run against charms in Charmhub.",
     )
+    parser.addoption(
+        "--clean-lxc-instances",
+        action="store_true",
+        default=False,
+        help="Whether to clean lxc instances created by charmcraft once deployment is successful."
+        "It defaults to False."
+    )

--- a/tests/integration/helpers/lxc.py
+++ b/tests/integration/helpers/lxc.py
@@ -1,0 +1,14 @@
+import sh
+import jq
+
+def clean_charmcraft_lxc_instances() -> None:
+    """
+    Delete lxc instances in project "charmcraft" that are prefixed with "charmcraft-".
+
+    Based on https://discourse.charmhub.io/t/how-to-quickly-clean-unused-lxd-instances-from-charmcraft-pack/15975
+    """
+    lxc_instances = sh.lxc.list(project="charmcraft", format="json")
+    lxc_instances_charmcraft = jq.compile('.[] | select(.name | startswith("charmcraft-")) | .name').input_text(lxc_instances).all()
+    for instance in lxc_instances_charmcraft:
+        print(f"Deleting lxc instance '{instance}'")
+        sh.lxc.delete(instance, project="charmcraft")

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -19,6 +19,7 @@ from kfp_globals import (
     SAMPLE_VIEWER,
 )
 
+import sh
 import jq
 import kfp
 import lightkube

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from helpers.bundle_mgmt import render_bundle, deploy_bundle
 from helpers.k8s_resources import apply_manifests, fetch_response
 from helpers.localize_bundle import get_resources_from_charm_file
+from helpers.lxc import clean_charmcraft_lxc_instances
 from kfp_globals import (
     CHARM_PATH_TEMPLATE,
     KFP_CHARMS,
@@ -18,6 +19,7 @@ from kfp_globals import (
     SAMPLE_VIEWER,
 )
 
+import jq
 import json
 import kfp
 import lightkube
@@ -71,6 +73,7 @@ def create_and_clean_experiment_v2(kfp_client: kfp.Client):
 async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     """Build and deploy kfp-operators charms."""
     no_build = request.config.getoption("no_build")
+    clean_lxc_instances = True if request.config.getoption("--clean-lxc-instances") else False
 
     # Immediately raise an error if the model name is not kubeflow
     if ops_test.model_name != "kubeflow":
@@ -95,6 +98,9 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
             charm_resources = get_resources_from_charm_file(charm_file)
             context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
             context.update([(f"{charm.replace('-', '_')}", charm_file)])
+
+        if clean_lxc_instances == True:
+            clean_charmcraft_lxc_instances()
 
     # Render kfp-operators bundle file with locally built charms and their resources
     rendered_bundle = render_bundle(


### PR DESCRIPTION
More details on the issue.

Fix #602

### Testing
This is essentially verified on the PR's CI run. In order to verify that it doesn't affect running locally (without `--clean-lxc-instances`), you can try triggering a run without it. Note that the CI can fail due to #601.