### PR TITLE
fix(ci): Add track_model before wait_for_idle

### DIFF
--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -101,6 +101,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Deploy the kfp-operators bundle from the rendered bundle file
     await deploy_bundle(ops_test, bundle_path=rendered_bundle, trust=True)
 
+    # Add due to https://github.com/canonical/kfp-operators/issues/601
+    log.info("Connecting to model Kubeflow")
+    await ops_test.track_model("kubeflow", model_name="kubeflow", use_existing=True)
+    log.info("Waiting for model to be active")
     # Wait for everything to be up.  Note, at time of writing these charms would naturally go
     # into blocked during deploy while waiting for each other to satisfy relations, so we don't
     # raise_on_blocked.

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -104,6 +104,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Deploy the kfp-operators bundle from the rendered bundle file
     await deploy_bundle(ops_test, bundle_path=rendered_bundle, trust=True)
 
+    # Add due to https://github.com/canonical/kfp-operators/issues/601
+    log.info("Connecting to model Kubeflow")
+    await ops_test.track_model("kubeflow", model_name="kubeflow", use_existing=True)
+    log.info("Waiting for model to be active")
     # Wait for everything to be up.  Note, at time of writing these charms would naturally go
     # into blocked during deploy while waiting for each other to satisfy relations, so we don't
     # raise_on_blocked.


### PR DESCRIPTION
Use [track_model](https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md#async-def-track_modelself-alias-str-model_name-optionalstr--none-cloud_name-optionalstr--none-use_existing-optionalbool--none-keep-optionalmodelkeep-str-bool-none--modelkeepif_exists-destroy_storage-bool--false-kwargs---model) in order to ensure that ops_test hasn't been disconnected from `kubfelow` model.

Ref #601