### PR TITLE
fix(ci): Use `juju wait-for` instead wait_for_idle()

### DIFF
--- a/requirements-integration-v1.in
+++ b/requirements-integration-v1.in
@@ -11,3 +11,4 @@ pytest
 pytest-operator
 pyyaml
 tenacity
+sh

--- a/requirements-integration-v1.txt
+++ b/requirements-integration-v1.txt
@@ -272,6 +272,8 @@ rich==13.7.1
     # via typer
 rsa==4.9
     # via google-auth
+sh==2.1.0
+    # via -r requirements-integration-v1.in
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -18,6 +18,7 @@ from kfp_globals import (
     SAMPLE_VIEWER,
 )
 
+import sh
 import kfp
 import lightkube
 import pytest
@@ -101,16 +102,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Deploy the kfp-operators bundle from the rendered bundle file
     await deploy_bundle(ops_test, bundle_path=rendered_bundle, trust=True)
 
-    # Wait for everything to be up.  Note, at time of writing these charms would naturally go
-    # into blocked during deploy while waiting for each other to satisfy relations, so we don't
-    # raise_on_blocked.
-    await ops_test.model.wait_for_idle(
-        status="active",
-        raise_on_blocked=False,  # These apps block while waiting for each other to deploy/relate
-        raise_on_error=True,
-        timeout=3600,
-        idle_period=30,
-    )
+    # Use `juju wait-for` instead of `wait_for_idle()`
+    # due to https://github.com/canonical/kfp-operators/issues/601
+    log.info("Waiting on model applications to be active")
+    sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
 
 
 # ---- KFP API Server focused test cases

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -104,6 +104,7 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
 
     # Use `juju wait-for` instead of `wait_for_idle()`
     # due to https://github.com/canonical/kfp-operators/issues/601
+    # and https://github.com/juju/python-libjuju/issues/1204
     log.info("Waiting on model applications to be active")
     sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
 

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -104,17 +104,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Deploy the kfp-operators bundle from the rendered bundle file
     await deploy_bundle(ops_test, bundle_path=rendered_bundle, trust=True)
 
-    # Wait for everything to be up.  Note, at time of writing these charms would naturally go
-    # into blocked during deploy while waiting for each other to satisfy relations, so we don't
-    # raise_on_blocked.
-    await ops_test.model.wait_for_idle(
-        status="active",
-        raise_on_blocked=False,  # These apps block while waiting for each other to deploy/relate
-        raise_on_error=True,
-        timeout=3600,
-        idle_period=30,
-    )
-
+    # Use `juju wait-for` instead of `wait_for_idle()`
+    # due to https://github.com/canonical/kfp-operators/issues/601
+    log.info("Waiting on model applications to be active")
+    sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
 
 # ---- KFP API Server focused test cases
 async def test_upload_pipeline(kfp_client):

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -106,6 +106,7 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
 
     # Use `juju wait-for` instead of `wait_for_idle()`
     # due to https://github.com/canonical/kfp-operators/issues/601
+    # and https://github.com/juju/python-libjuju/issues/1204
     log.info("Waiting on model applications to be active")
     sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
 


### PR DESCRIPTION
This is a workaround for #601. Changes should be reverted for uniformity among our charms once upstream https://github.com/juju/python-libjuju/issues/1204 is fixed.

Closes #601 

### Testing
The CI has been rerun 4 times successfully (from the first commit). 