### PR TITLE
ci, fix: change profile of mysql-k8s to testing, skip artefact collection on success

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -179,8 +179,8 @@ jobs:
         run: juju status
         if: failure()
 
-      # Collect debug artefacts only on failure as the CI for this repository
+      # Collect debug artefacts only on failure || cancelled as the CI for this repository
       # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: failure()
+        if: failure() || cancelled()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -179,6 +179,8 @@ jobs:
         run: juju status
         if: failure()
 
+      # Collect debug artefacts only on failure as the CI for this repository
+      # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: always()
+        if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -171,6 +171,10 @@ jobs:
           juju add-model kubeflow
           sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --charmcraft-clean
 
+      - name: Display df
+        run: df -h
+        if: always()
+
       - name: Get all
         run: kubectl get all -A
         if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -171,10 +171,6 @@ jobs:
           juju add-model kubeflow
           sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --charmcraft-clean
 
-      - name: Display df
-        run: df -h
-        if: always()
-
       - name: Get all
         run: kubectl get all -A
         if: failure()

--- a/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
@@ -4,7 +4,6 @@ applications:
   argo-controller:         { charm: ch:argo-controller, channel: 3.3.10/stable, scale: 1, trust: true }
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: 3.0/stable, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: ckf-1.8/stable,       scale: 1 }
-  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
   mlmd:                    { charm: ch:mlmd, channel: 1.14/stable, scale: 1 }
   envoy:                   { charm: ch:envoy, channel: 2.0/stable, scale: 1 }
   kubeflow-profiles:       { charm: ch:kubeflow-profiles, channel: 1.8/stable, scale: 1, trust: true }
@@ -21,6 +20,13 @@ applications:
     scale: 1
     options:
       default-gateway: kubeflow-gateway
+    trust: true
+  kfp-db:
+    charm: mysql-k8s
+    channel: 8.0/stable
+    scale: 1
+    options:
+      profile: testing
     trust: true
   kubeflow-roles:
     charm: kubeflow-roles

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -4,7 +4,6 @@ applications:
   argo-controller:         { charm: ch:argo-controller, channel: latest/edge, scale: 1, trust: true }
   metacontroller-operator: { charm: ch:metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
   minio:                   { charm: ch:minio, channel: latest/edge,       scale: 1 }
-  kfp-db:                  { charm: ch:mysql-k8s, channel: 8.0/stable, scale: 1, constraints: mem=2G, trust: true }
   mlmd:                    { charm: ch:mlmd, channel: latest/edge, scale: 1, trust: true}
   envoy:                   { charm: ch:envoy, channel: latest/edge, scale: 1 }
   kubeflow-profiles:       { charm: ch:kubeflow-profiles, channel: latest/edge, scale: 1, trust: true }
@@ -21,6 +20,13 @@ applications:
     scale: 1
     options:
       default-gateway: kubeflow-gateway
+    trust: true
+  kfp-db:
+    charm: mysql-k8s
+    channel: 8.0/stable
+    scale: 1
+    options:
+      profile: testing
     trust: true
   kubeflow-roles:
     charm: kubeflow-roles


### PR DESCRIPTION
This PR introduces the following changes to help alleviate the Github runners disk pressure.

* ci, fix: change profile of mysql-k8s to testing
 
The mysql-k8s charm, used as kfp-db, has a profile configuration option that can
be set to testing which sets the scope of deployment. This option configures the
sizes of buffers it uses to a small number (and it allocates those buffers upon startup);
otherwise, it uses the pod's resources as it should in production. If the pod has resource
limits, the buffers will be allocated relative to these resource limits; otherwise it will
allocate relative to host machine's resources.
This is recommended for testing environments.

* ci: skip collection of debug artefacts on success

The Github runners for the KFP CI are getting out of storage by the
time the tests execution finishes, so there is no space left for saving
logs. Skipping saving the debug artefacts on success will allow the workflows
to run successfully.