### PR TITLE
ci: use get_charms_build_with_cache.yaml workflow

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -3,19 +3,24 @@ name: On Pull Request
 # On pull_request, we:
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
-
+# * always run builds with cache
 on:
   pull_request:
 
 jobs:
+  get-paths-and-build:
+    name: Get charm paths and build with cache
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_charms_build_with_cache.yaml@KF-6690-build-with-cache
 
   tests:
     name: Run Tests
+    needs: [get-paths-and-build]
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
+    needs: [get-paths-and-build]
     uses: ./.github/workflows/publish.yaml
     secrets: inherit

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   get-paths-and-build:
     name: Get charm paths and build with cache
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_charms_build_with_cache.yaml@KF-6690-build-with-cache
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_charms_build_with_cache.yaml@main
 
   tests:
     name: Run Tests


### PR DESCRIPTION
This workflow enables the usage of canonical/charmed-kubeflow-workflows/.github/workflows/get_charms_build_with_cache.yaml for this CI, meaning that the integration tests and publish jobs are now able to download charm artefacts and use them consistently throught the various operations of this CI.

Fixes #641

Review and merge after https://github.com/canonical/charmed-kubeflow-workflows/pull/88