### PR TITLE
ci: remove wrapper around get charm paths and build with cache workflows

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -134,7 +134,7 @@ jobs:
         timeout-minutes: 5
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.artifact-prefix }}-${{ matrix.charm }}-*
+          pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
 
       - name: Integration tests
@@ -145,7 +145,7 @@ jobs:
           # Pass the path where the charm artefact is downloaded to the tox command
           # FIXME: Right now the complete path is half hardcoded to <charm name>_ubuntu-20.04-amd64.charm
           # We need to find a better way to dynamically get this value
-          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu-20.04-amd64.charm"
+          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm"
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,6 +6,14 @@ on:
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: true
+    inputs:
+      artifact-prefix:
+        description: |
+          Prefix for charm package GitHub artifact(s)
+
+          Use canonical/data-platform-workflows build_charm.yaml to build the charm(s)
+        required: true
+        type: string
 
 jobs:
   lib-check:
@@ -126,7 +134,7 @@ jobs:
         timeout-minutes: 5
         uses: actions/download-artifact@v4
         with:
-          pattern: packed-charm-cache-true-.-charms-${{ matrix.charm }}-*
+          pattern: ${{ inputs.artifact-prefix }}-${{ matrix.charm }}-*
           merge-multiple: true
 
       - name: Integration tests

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -38,6 +38,8 @@ jobs:
     needs: build
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
+    with:
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,9 +8,31 @@ on:
   pull_request:
 
 jobs:
-  get-paths-and-build:
-    name: Get charm paths and build with cache
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_charms_build_with_cache.yaml@main
+  get-charm-paths:
+    name: Generate the Charm Matrix content
+    runs-on: ubuntu-latest
+    outputs:
+      charm_paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get paths for all charms in this repo
+        id: get-charm-paths
+        uses: canonical/kubeflow-ci/actions/get-charm-paths@main
+
+  build:
+    name: Build charms
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v24.0.5
+    needs: get-charm-paths
+    strategy:
+      fail-fast: false
+      matrix:
+        charm: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths) }}
+    with:
+      cache: true 
+      charmcraft-snap-channel: 3.x/stable
+      path-to-charm-directory: ./${{ matrix.charm }}
 
   tests:
     name: Run Tests

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -22,12 +22,12 @@ jobs:
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
 
   build:
-    name: Build charms
+    name: Build charm | ${{ matrix.charm }}
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.1
     needs: get-charm-paths
     strategy:
       matrix:
-        charm: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths.outputs.charm_paths) }}
     with:
       # Update to 3.x/stable once the latest/candidate is released to that track
       charmcraft-snap-channel: latest/candidate

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Generate the Charm Matrix content
     runs-on: ubuntu-latest
     outputs:
-      charm_paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
+      charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,15 +22,14 @@ jobs:
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
 
   build:
-    name: Build charm | ${{ matrix.charm }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.1
-    needs: get-charm-paths
     strategy:
       matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths.outputs.charm_paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths.outputs.charm-paths) }}
+    name: Build charm | ${{ matrix.charm }}
+    needs:
+      - get-charm-paths
     with:
-      # Update to 3.x/stable once the latest/candidate is released to that track
-      charmcraft-snap-channel: latest/candidate
+      charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
       path-to-charm-directory: ${{ matrix.charm }}
 
   tests:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -23,7 +23,6 @@ jobs:
 
   build:
     name: Build charms
-    needs: [get-charm-paths]
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v24.0.5
     needs: get-charm-paths
     strategy:
@@ -37,13 +36,13 @@ jobs:
 
   tests:
     name: Run Tests
-    needs: [build]
+    needs: build
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
-    needs: [build]
+    needs: build
     uses: ./.github/workflows/publish.yaml
     secrets: inherit

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -28,6 +28,7 @@ jobs:
     name: Build charm | ${{ matrix.charm }}
     needs:
       - get-charm-paths
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
     with:
       charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
       path-to-charm-directory: ${{ matrix.charm }}

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -23,6 +23,7 @@ jobs:
 
   build:
     name: Build charms
+    needs: [get-charm-paths]
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v24.0.5
     needs: get-charm-paths
     strategy:
@@ -36,13 +37,13 @@ jobs:
 
   tests:
     name: Run Tests
-    needs: [get-paths-and-build]
+    needs: [build]
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
-    needs: [get-paths-and-build]
+    needs: [build]
     uses: ./.github/workflows/publish.yaml
     secrets: inherit

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -23,16 +23,15 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v24.0.5
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.1
     needs: get-charm-paths
     strategy:
-      fail-fast: false
       matrix:
         charm: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths) }}
     with:
-      cache: true 
-      charmcraft-snap-channel: 3.x/stable
-      path-to-charm-directory: ./${{ matrix.charm }}
+      # Update to 3.x/stable once the latest/candidate is released to that track
+      charmcraft-snap-channel: latest/candidate
+      path-to-charm-directory: ${{ matrix.charm }}
 
   tests:
     name: Run Tests

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -92,4 +92,3 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
-          destructive-mode: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,12 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+      # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
+        charm-path: ${{ fromJSON(needs.get-charm-paths.outputs.charm_paths_list) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,12 +83,6 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
-      # Required to charmcraft pack in non-destructive mode
-      - name: Setup lxd
-        uses: canonical/setup-lxd@v0.1.2
-        with:
-          channel: latest/stable
-
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -92,3 +92,4 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
+          destructive-mode: false


### PR DESCRIPTION
This commit removes the extra abstraction of the get-charm-paths action and build_charm.yaml reusable workflow to avoid potential incompatibilities and sync issues with the data platforms workflows.

Notes to reviewer:
* the bundle tests will be addressed in #654 
* the on push workflow is now broken due to the changes, and it will be addressed in #650 
* the release and publish workflow will be addressed in #656 