### PR TITLE
ci: use cache built charms in bundle tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,6 +204,8 @@ jobs:
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        with:
+          artifact-prefix: ${{ matrix.charm }}
         if: always()
 
   test-bundle:
@@ -264,4 +266,6 @@ jobs:
       # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        with:
+          artifact-prefix: ${{ matrix.sdk }}
         if: failure() || cancelled()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,7 @@ jobs:
     name: Release charm to Charmhub branch | ${{ matrix.charm }}
     if: ${{ github.event_name == 'pull_request' }}
     needs:
+      - get-charm-paths-channel
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,6 +238,14 @@ jobs:
           charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 
+      - name: Download packed charm(s)
+        id: download-charms
+        timeout-minutes: 5
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+
       - name: Run test
         run: |
           # Requires the model to be called kubeflow due to kfp-viewer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -250,7 +250,7 @@ jobs:
         run: |
           # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
-          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --charmcraft-clean
+          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2"
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,7 +241,7 @@ jobs:
         run: |
           # Requires the model to be called kubeflow due to kfp-viewer
           juju add-model kubeflow
-          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --charmcraft-clean
+          sg snap_microk8s -c "tox -e bundle-integration-${{ matrix.sdk }} -- --model kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=./tests/integration/bundles/kfp_latest_edge.yaml.j2" --charmcraft-clean
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,7 @@ jobs:
 
   test-bundle:
     name: Test the bundle
+    needs: build
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,8 @@ This directory has the following structure:
 * Microk8s addons: metallb, hostpath-storage, dns
 > NOTE: Metallb is enabled with an arbitrary IP range 10.64.140.43-10.64.140.49
 * juju
-* charmcraft (only for testing with locally built charms)
+* charmcraft (only for testing the charms locally using option A)
+* charmcraftcache (only for testing the charms locally using option B)
 * tox
 * lxd (only for testing with locally built and if `destructive-mode` is not enabled)
 
@@ -57,11 +58,30 @@ Communication with the KFP API happens using the KFP Python SDK. A `kfp.client` 
 1. Create a `kubeflow` model with `juju add-model kubeflow`
 2. Run integration tests against the preferred bundle definition in `integration/bundles`
 
-```
-tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> --charms-path <built_charms_path> <--charmcraft-clean>
-```
+    Option A - Build charms with charmcraft
+
+    * Install charmcraft
+    * Run the tests with the command:
+    ```
+    tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> <--charmcraft-clean>
+    ```
+    This builds the charms sequentially with `charmcraft` through `ops_test.build_charm`, then deploys them.
+
+    Option B - Build charms with ccc
+    * Install [charmcraftcache](https://github.com/canonical/charmcraftcache?tab=readme-ov-file#installation)
+    * Go into each charm directory and pack the charm with `ccc`. For example:
+    ```
+    cd charms/kfp-api
+    ccc pack
+    ```
+    * Run the tests with the command:
+    ```
+    tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> --charms-path /charms/
+    ```
+    This immediately deploys the charms packed with `ccc` before running the tests.
 
 Where,
 * `--model` tells the testing framework which model to deploy charms to
 * `--bundle` is the path to a bundle template that's going to be used during the test execution
+* `--charms-path` is the path to the built charms when using option B
 * `--charmcraft-clean` tells the test suite whether to run `charmcraft clean` and delete the lxc instances after building the charms. If `--charms-path` is passed, this has no effect.

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,7 @@ This directory has the following structure:
 
 #### Functional tests
 
-The test suite for functional tests will deploy the `kfp_1.7_stable_install.yaml.j2` bundle, upload a pipeline, create an experiment, create a run and a recurring run, and run health checks on the visualisation and viewer servers.
+The test suite for functional tests will deploy the `kfp_latest_edge.yaml.j2` bundle, upload a pipeline, create an experiment, create a run and a recurring run, and run health checks on the visualisation and viewer servers.
 Communication with the KFP API happens using the KFP Python SDK. A `kfp.client` is configured using a test profile (`Profile`) to be able to execute pipeline operations (create runs, experiments, upload pipelines, etc.).
 
 > NOTE: This test suite does not deploy the `kfp-profile-controller` as the tests for that component are already covered in the charm's directory.
@@ -58,11 +58,10 @@ Communication with the KFP API happens using the KFP Python SDK. A `kfp.client` 
 2. Run integration tests against the preferred bundle definition in `integration/bundles`
 
 ```
-tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> <--no-build> <--charmcraft-clean>
+tox -e bundle-integration -- --model kubeflow --bundle=./tests/integration/bundles/<bundle_template> --charms-path <built_charms_path> <--charmcraft-clean>
 ```
 
 Where,
 * `--model` tells the testing framework which model to deploy charms to
 * `--bundle` is the path to a bundle template that's going to be used during the test execution
-* `--no-build` tells the test suite whether to build charms and run tests against them, or use charms in Charmhub
-* `--charmcraft-clean` tells the test suite whether to run `charmcraft clean` and delete the lxc instances after building the charms. If `--no-build` is passed, this has no effect.
+* `--charmcraft-clean` tells the test suite whether to run `charmcraft clean` and delete the lxc instances after building the charms. If `--charms-path` is passed, this has no effect.

--- a/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.7_stable_install.yaml.j2
@@ -43,37 +43,6 @@ applications:
     channel: 1.7/stable
     scale: 1
     trust: true
-{%- if local_build == false %}
-  kfp-api:
-    charm: kfp-api
-    channel: 2.0-alpha.7/stable
-    scale: 1
-    trust: true
-  kfp-persistence:
-    charm: kfp-persistence
-    channel: 2.0-alpha.7/stable
-    scale: 1
-  kfp-profile-controller:
-    charm: kfp-profile-controller
-    channel: 2.0-alpha.7/stable
-    scale: 1
-  kfp-schedwf:
-    charm: kfp-schedwf
-    channel: 2.0-alpha.7/stable
-    scale: 1
-  kfp-ui:
-    charm: kfp-ui
-    channel: 2.0-alpha.7/stable
-    scale: 1
-  kfp-viewer:
-    charm: kfp-viewer
-    channel: 2.0-alpha.7/stable
-    scale: 1
-  kfp-viz:
-    charm: kfp-viz
-    channel: 2.0-alpha.7/stable
-    scale: 1
-{% else %}
   kfp-api:
     charm: {{ kfp_api }}
     resources: {{ kfp_api_resources }}
@@ -103,7 +72,6 @@ applications:
     charm: {{ kfp_viz }}
     resources: {{ kfp_viz_resources }}
     scale: 1
-{%- endif %}
 relations:
 - - kfp-api:kfp-api
   - kfp-persistence:kfp-api

--- a/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
+++ b/tests/integration/bundles/kfp_1.8_stable_install.yaml.j2
@@ -33,16 +33,6 @@ applications:
     channel: 1.8/stable
     scale: 1
     trust: true
-{%- if local_build == false %}
-  kfp-api:                 { charm: ch:kfp-api, channel: 2.0/stable, scale: 1, trust: true}
-  kfp-metadata-writer:     { charm: ch:kfp-metadata-writer, channel: 2.0/stable, scale: 1, trust: true}
-  kfp-persistence:         { charm: ch:kfp-persistence, channel: 2.0/stable, scale: 1, trust: true }
-  kfp-profile-controller:  { charm: ch:kfp-profile-controller, channel: 2.0/stable, scale: 1, trust: true }
-  kfp-schedwf:             { charm: ch:kfp-schedwf, channel: 2.0/stable, scale: 1, trust: true}
-  kfp-ui:                  { charm: ch:kfp-ui, channel: 2.0/stable, trust: true,            scale: 1 }
-  kfp-viewer:              { charm: ch:kfp-viewer, channel: 2.0/stable, trust: true,         scale: 1 }
-  kfp-viz:                 { charm: ch:kfp-viz, channel: 2.0/stable, trust: true,         scale: 1 }
-{%- else %}
   kfp-api:
     charm: {{ kfp_api }}
     resources: {{ kfp_api_resources }}
@@ -83,7 +73,6 @@ applications:
     resources: {{ kfp_viz_resources }}
     scale: 1
     trust: true
-{%- endif %}
 relations:
 - [argo-controller:object-storage, minio:object-storage]
 - [kfp-api:relational-db, kfp-db:database]

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -33,7 +33,7 @@ applications:
     channel: latest/edge
     scale: 1
     trust: true
-{%- if local_build == false %}
+{%- if local_build == false and cached_build == false %}
   kfp-api:                 { charm: ch:kfp-api, channel: latest/edge, scale: 1, trust: true}
   kfp-metadata-writer:     { charm: ch:kfp-metadata-writer, channel: latest/edge, scale: 1, trust: true}
   kfp-persistence:         { charm: ch:kfp-persistence, channel: latest/edge, scale: 1, trust: true }

--- a/tests/integration/bundles/kfp_latest_edge.yaml.j2
+++ b/tests/integration/bundles/kfp_latest_edge.yaml.j2
@@ -33,16 +33,6 @@ applications:
     channel: latest/edge
     scale: 1
     trust: true
-{%- if local_build == false and cached_build == false %}
-  kfp-api:                 { charm: ch:kfp-api, channel: latest/edge, scale: 1, trust: true}
-  kfp-metadata-writer:     { charm: ch:kfp-metadata-writer, channel: latest/edge, scale: 1, trust: true}
-  kfp-persistence:         { charm: ch:kfp-persistence, channel: latest/edge, scale: 1, trust: true }
-  kfp-profile-controller:  { charm: ch:kfp-profile-controller, channel: latest/edge, scale: 1, trust: true }
-  kfp-schedwf:             { charm: ch:kfp-schedwf, channel: latest/edge, scale: 1, trust: true}
-  kfp-ui:                  { charm: ch:kfp-ui, channel: latest/edge, trust: true,            scale: 1 }
-  kfp-viewer:              { charm: ch:kfp-viewer, channel: latest/edge, trust: true         scale: 1 }
-  kfp-viz:                 { charm: ch:kfp-viz, channel: latest/edge, trust: true         scale: 1 }
-{%- else %}
   kfp-api:
     charm: {{ kfp_api }}
     resources: {{ kfp_api_resources }}
@@ -83,7 +73,6 @@ applications:
     resources: {{ kfp_viz_resources }}
     scale: 1
     trust: true
-{%- endif %}
 relations:
 - [argo-controller:object-storage, minio:object-storage]
 - [kfp-api:relational-db, kfp-db:database]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,3 +111,7 @@ def pytest_addoption(parser: Parser):
         help="Whether to run charmcraft clean and delete lxc instances created by charmcraft."
         "It defaults to False."
     )
+    parser.addoption(
+        "--charms-path",
+        help="Path to directory where charm files are stored.",
+    )

--- a/tests/integration/helpers/bundle_mgmt.py
+++ b/tests/integration/helpers/bundle_mgmt.py
@@ -23,7 +23,7 @@ def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict, no_build:
     """
     if no_build:
         context.update([("local_build", False)])
-    context.update(["cached_build", cached_build])
+    context.update([("cached_build", cached_build)])
     # Render the bundle and get its path
     # The pytest-operator will save it in `self.tmp_path / "bundles"`
     logger.debug(f"Rendering the bundle in {bundle_path} with context {context}")

--- a/tests/integration/helpers/bundle_mgmt.py
+++ b/tests/integration/helpers/bundle_mgmt.py
@@ -10,20 +10,13 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict, no_build: bool, cached_build: bool) -> Path:
+def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict) -> Path:
     """Render a templated bundle and return its file path.
 
     Args:
         bundle_path (Path): Path to bundle file.
         context (dict): Context mapping to render the bundle file.
-        local_build (bool): Selector for rendering the bundle with locally built
-            charms context (charm file path and resources).
-        cached_build (bool): Selector for rendering the bundle with cache built
-            charms context.
     """
-    if no_build:
-        context.update([("local_build", False)])
-    context.update([("cached_build", cached_build)])
     # Render the bundle and get its path
     # The pytest-operator will save it in `self.tmp_path / "bundles"`
     logger.debug(f"Rendering the bundle in {bundle_path} with context {context}")

--- a/tests/integration/helpers/bundle_mgmt.py
+++ b/tests/integration/helpers/bundle_mgmt.py
@@ -10,7 +10,7 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict, no_build: bool) -> Path:
+def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict, no_build: bool, cached_build: bool) -> Path:
     """Render a templated bundle and return its file path.
 
     Args:
@@ -18,9 +18,12 @@ def render_bundle(ops_test: OpsTest, bundle_path: Path, context: dict, no_build:
         context (dict): Context mapping to render the bundle file.
         local_build (bool): Selector for rendering the bundle with locally built
             charms context (charm file path and resources).
+        cached_build (bool): Selector for rendering the bundle with cache built
+            charms context.
     """
     if no_build:
         context.update([("local_build", False)])
+    context.update(["cached_build", cached_build])
     # Render the bundle and get its path
     # The pytest-operator will save it in `self.tmp_path / "bundles"`
     logger.debug(f"Rendering the bundle in {bundle_path} with context {context}")

--- a/tests/integration/helpers/localize_bundle.py
+++ b/tests/integration/helpers/localize_bundle.py
@@ -45,6 +45,11 @@ def get_resources_from_charm_file(charm_file: str) -> Dict[str, str]:
         return {k: v["upstream-source"] for k, v in resources.items()}
     open_charm_file = charm_file
 
+def update_charm_context(context, charm_name, charm_path):
+    """Updates the context dict with the charm resources and charm artifact path"""
+    charm_resources = get_resources_from_charm_file(charm_path)
+    context.update([(f"{charm_name.replace('-', '_')}_resources", charm_resources)])
+    context.update([(f"{charm_name.replace('-', '_')}", charm_path)])
 
 def localize_bundle_application(
     bundle: dict,

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -70,6 +70,7 @@ def create_and_clean_experiment_v1(kfp_client: kfp.Client):
 async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     """Build and deploy kfp-operators charms."""
     no_build = request.config.getoption("no_build")
+    cached_build = True if request.config.getoption("--charms-path", default=None) else False
     charmcraft_clean_flag = True if request.config.getoption("--charmcraft-clean") else False
 
     # Immediately raise an error if the model name is not kubeflow
@@ -82,26 +83,34 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
 
     # Build the charms we need to build only if --no-build is not set
     context = {}
-    if not no_build:
-        charms_to_build = {
-            charm: Path(CHARM_PATH_TEMPLATE.format(basedir=str(basedir), charm=charm))
-            for charm in KFP_CHARMS
-        }
-        log.info(f"Building charms for: {charms_to_build}")
-        built_charms = await ops_test.build_charms(*charms_to_build.values())
-        log.info(f"Built charms: {built_charms}")
 
-        for charm, charm_file in built_charms.items():
-            charm_resources = get_resources_from_charm_file(charm_file)
+    if charms_path := request.config.getoption("--charms-path"):
+        for charm in KFP_CHARMS:
+            cached_charm_file = f"{charms_path}/{charm}/{charm}_ubuntu@20.04-amd64.charm"
+            charm_resources = get_resources_from_charm_file(cached_charm_file)
             context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
-            context.update([(f"{charm.replace('-', '_')}", charm_file)])
+            context.update([(f"{charm.replace('-', '_')}", cached_charm_file)])
+    else:
+        if not no_build:
+            charms_to_build = {
+                charm: Path(CHARM_PATH_TEMPLATE.format(basedir=str(basedir), charm=charm))
+                for charm in KFP_CHARMS
+            }
+            log.info(f"Building charms for: {charms_to_build}")
+            built_charms = await ops_test.build_charms(*charms_to_build.values())
+            log.info(f"Built charms: {built_charms}")
 
-        if charmcraft_clean_flag == True:
-            charmcraft_clean(charms_to_build)
+            for charm, charm_file in built_charms.items():
+                charm_resources = get_resources_from_charm_file(charm_file)
+                context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
+                context.update([(f"{charm.replace('-', '_')}", charm_file)])
+
+            if charmcraft_clean_flag == True:
+                charmcraft_clean(charms_to_build)
 
     # Render kfp-operators bundle file with locally built charms and their resources
     rendered_bundle = render_bundle(
-        ops_test, bundle_path=bundlefile_path, context=context, no_build=no_build
+        ops_test, bundle_path=bundlefile_path, context=context, no_build=no_build, cached_build=cached_build
     )
 
     # Deploy the kfp-operators bundle from the rendered bundle file

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -90,23 +90,23 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
             charm_resources = get_resources_from_charm_file(cached_charm_file)
             context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
             context.update([(f"{charm.replace('-', '_')}", cached_charm_file)])
-    else:
-        if not no_build:
-            charms_to_build = {
-                charm: Path(CHARM_PATH_TEMPLATE.format(basedir=str(basedir), charm=charm))
-                for charm in KFP_CHARMS
-            }
-            log.info(f"Building charms for: {charms_to_build}")
-            built_charms = await ops_test.build_charms(*charms_to_build.values())
-            log.info(f"Built charms: {built_charms}")
+    # else:
+    #     if not no_build:
+    #         charms_to_build = {
+    #             charm: Path(CHARM_PATH_TEMPLATE.format(basedir=str(basedir), charm=charm))
+    #             for charm in KFP_CHARMS
+    #         }
+    #         log.info(f"Building charms for: {charms_to_build}")
+    #         built_charms = await ops_test.build_charms(*charms_to_build.values())
+    #         log.info(f"Built charms: {built_charms}")
 
-            for charm, charm_file in built_charms.items():
-                charm_resources = get_resources_from_charm_file(charm_file)
-                context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
-                context.update([(f"{charm.replace('-', '_')}", charm_file)])
+    #         for charm, charm_file in built_charms.items():
+    #             charm_resources = get_resources_from_charm_file(charm_file)
+    #             context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
+    #             context.update([(f"{charm.replace('-', '_')}", charm_file)])
 
-            if charmcraft_clean_flag == True:
-                charmcraft_clean(charms_to_build)
+    #         if charmcraft_clean_flag == True:
+    #             charmcraft_clean(charms_to_build)
 
     # Render kfp-operators bundle file with locally built charms and their resources
     rendered_bundle = render_bundle(

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from helpers.bundle_mgmt import render_bundle, deploy_bundle
 from helpers.k8s_resources import apply_manifests, fetch_response
-from helpers.localize_bundle import get_resources_from_charm_file
+from helpers.localize_bundle import update_charm_context
 from helpers.charmcraft import charmcraft_clean
 from kfp_globals import (
     CHARM_PATH_TEMPLATE,
@@ -84,10 +84,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Find charms in the expected path if `--charms-path` is passed
     if charms_path := request.config.getoption("--charms-path"):
         for charm in KFP_CHARMS:
+            # NOTE: The full path for the charm is hardcoded here. It relies on the downloaded
+            # artifacts having the format below and existing in the exact path under `charms_path`.
             cached_charm = f"{charms_path}/{charm}/{charm}_ubuntu@20.04-amd64.charm"
-            charm_resources = get_resources_from_charm_file(cached_charm)
-            context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
-            context.update([(f"{charm.replace('-', '_')}", cached_charm)])
+            update_charm_context(context, charm, cached_charm)
     # Otherwise build the charms with ops_test
     else:
         charms_to_build = {
@@ -100,9 +100,7 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
         for charm_name, charm_path in charms_to_build.items():
             log.info(f" Building charm {charm_name}")
             built_charm = await ops_test.build_charm(charm_path)
-            charm_resources = get_resources_from_charm_file(built_charm)
-            context.update([(f"{charm_name.replace('-', '_')}_resources", charm_resources)])
-            context.update([(f"{charm_name.replace('-', '_')}", built_charm)])
+            update_charm_context(context, charm_name, built_charm)
 
         if charmcraft_clean_flag == True:
             charmcraft_clean(charms_to_build)

--- a/tests/integration/test_kfp_functional_v1.py
+++ b/tests/integration/test_kfp_functional_v1.py
@@ -119,9 +119,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Use `juju wait-for` instead of `wait_for_idle()`
     # due to https://github.com/canonical/kfp-operators/issues/601
     # and https://github.com/juju/python-libjuju/issues/1204
+    # Also check status of the unit instead of application due to
+    # https://github.com/juju/juju/issues/18625
     log.info("Waiting on model applications to be active")
-    sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
-
+    sh.juju("wait-for","model","kubeflow", query="forEach(units, unit => unit.workload-status == 'active')", timeout="30m")
 
 # ---- KFP API Server focused test cases
 async def test_upload_pipeline(kfp_client):

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -71,7 +71,6 @@ def create_and_clean_experiment_v2(kfp_client: kfp.Client):
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     """Build and deploy kfp-operators charms."""
-    no_build = request.config.getoption("no_build")
     charmcraft_clean_flag = True if request.config.getoption("--charmcraft-clean") else False
 
     # Immediately raise an error if the model name is not kubeflow
@@ -82,28 +81,37 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     bundlefile_path = Path(request.config.getoption("bundle"))
     basedir = Path("./").absolute()
 
-    # Build the charms we need to build only if --no-build is not set
     context = {}
-    if not no_build:
+
+    # Find charms in the expected path if `--charms-path` is passed
+    if charms_path := request.config.getoption("--charms-path"):
+        for charm in KFP_CHARMS:
+            cached_charm = f"{charms_path}/{charm}/{charm}_ubuntu@20.04-amd64.charm"
+            charm_resources = get_resources_from_charm_file(cached_charm)
+            context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
+            context.update([(f"{charm.replace('-', '_')}", cached_charm)])
+    # Otherwise build the charms with ops_test
+    else:
         charms_to_build = {
             charm: Path(CHARM_PATH_TEMPLATE.format(basedir=str(basedir), charm=charm))
             for charm in KFP_CHARMS
         }
         log.info(f"Building charms for: {charms_to_build}")
-        built_charms = await ops_test.build_charms(*charms_to_build.values())
-        log.info(f"Built charms: {built_charms}")
-
-        for charm, charm_file in built_charms.items():
-            charm_resources = get_resources_from_charm_file(charm_file)
-            context.update([(f"{charm.replace('-', '_')}_resources", charm_resources)])
-            context.update([(f"{charm.replace('-', '_')}", charm_file)])
+        
+        # Build charms sequentially
+        for charm_name, charm_path in charms_to_build.items():
+            log.info(f" Building charm {charm_name}")
+            built_charm = await ops_test.build_charm(charm_path)
+            charm_resources = get_resources_from_charm_file(built_charm)
+            context.update([(f"{charm_name.replace('-', '_')}_resources", charm_resources)])
+            context.update([(f"{charm_name.replace('-', '_')}", built_charm)])
 
         if charmcraft_clean_flag == True:
             charmcraft_clean(charms_to_build)
 
     # Render kfp-operators bundle file with locally built charms and their resources
     rendered_bundle = render_bundle(
-        ops_test, bundle_path=bundlefile_path, context=context, no_build=no_build
+        ops_test, bundle_path=bundlefile_path, context=context
     )
 
     # Deploy the kfp-operators bundle from the rendered bundle file

--- a/tests/integration/test_kfp_functional_v2.py
+++ b/tests/integration/test_kfp_functional_v2.py
@@ -112,8 +112,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request, lightkube_client):
     # Use `juju wait-for` instead of `wait_for_idle()`
     # due to https://github.com/canonical/kfp-operators/issues/601
     # and https://github.com/juju/python-libjuju/issues/1204
+    # Also check status of the unit instead of application due to
+    # https://github.com/juju/juju/issues/18625
     log.info("Waiting on model applications to be active")
-    sh.juju("wait-for","model","kubeflow", query="forEach(applications, app => app.status == 'active')", timeout="30m")
+    sh.juju("wait-for","model","kubeflow", query="forEach(units, unit => unit.workload-status == 'active')", timeout="30m")
 
 # ---- KFP API Server focused test cases
 async def test_upload_pipeline(kfp_client):


### PR DESCRIPTION
Closes #654 

This PR deprecates the `--no-build` option, that was used to deploy the charms from Charmhub and test them locally due to it not being used by the team.

## Summary
* adds step to download charms built with cache before running bundle integration tests
* adds `--charms-path` parameter to pass to integration tests
* refactors the bundle integration test files to use the downloaded charms

Note to reviewer:
the single charm integration tests are failing due to https://github.com/canonical/kubeflow-ci/issues/152, this should be fixed by #663 