### PR TITLE
remove charmcraft pin to latest/candidate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,6 @@ jobs:
       - get-charm-paths-channel
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
     with:
-      charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
       path-to-charm-directory: ${{ matrix.charm }}
 
   release:
@@ -140,7 +139,6 @@ jobs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:
-      charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
       channel: ${{ needs.get-charm-paths-channel.outputs.charm-channel }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
@@ -182,7 +180,6 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.6/stable
-          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
 
       - name: Download packed charm(s)
         id: download-charms
@@ -234,7 +231,6 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.6/stable
-          charmcraft-channel: latest/candidate # TODO: remove after charmcraft 3.3 stable release
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 
       - name: Run test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:
-      charmcraft-snap-channel: latest/candidate  # TODO: remove after charmcraft 3.3 stable release
       channel: ${{ inputs.destination_channel || needs.ci-tests.outputs.channel }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}


### PR DESCRIPTION
Removes the charmcraft channel pin now that charmcraft 3.3 is [released to stable](https://snapcraft.io/charmcraft)