### PR TITLE
fix: Update rock to one with proper service name

### DIFF
--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: charmedkubeflow/metadata-writer:2.3.0-519bac2
+    upstream-source: charmedkubeflow/metadata-writer:2.3.0-97a181d
 requires:
   grpc:
     interface: k8s-service


### PR DESCRIPTION
Update image to use the one published by canonical/pipelines-rocks#168 which updates the name of the service created.

Fix canonical/pipelines-rocks#166