### PR TITLE
chore: upgrade to 2.4.1

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -52,12 +52,12 @@ options:
   launcher-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L33
-    default: "ghcr.io/kubeflow/kfp-launcher:2.4.0"
+    default: "ghcr.io/kubeflow/kfp-launcher:2.4.1"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L35
-    default: "ghcr.io/kubeflow/kfp-driver:2.4.0"
+    default: "ghcr.io/kubeflow/kfp-driver:2.4.1"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string

--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -27,7 +27,7 @@ options:
       when uploading a new version of a pipeline
   cache-image:
     type: string
-    default: "gcr.io/google-containers/busybox"
+    default: "registry.k8s.io/busybox"
     description: Which image to list as the backing image for a pipeline run step pulled from cache
   cache-enabled:
     type: boolean
@@ -51,13 +51,13 @@ options:
     description: Default name of object storage bucket.
   launcher-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/src/v2/compiler/argocompiler/container.go#L33
-    default: "gcr.io/ml-pipeline/kfp-launcher@sha256:bef55a344574a25c557256d7c66cb19edacfd2008d694e5b6bb5b612d59feae0"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L33
+    default: "ghcr.io/kubeflow/kfp-launcher:2.4.0"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
-    # Source: https://github.com/kubeflow/pipelines/blob/2.3.0/backend/src/v2/compiler/argocompiler/container.go#L35
-    default: "gcr.io/ml-pipeline/kfp-driver@sha256:dc8b56a2eb071f30409828a8884d621092e68385af11a6c06aa9e9fbcfbb19de"
+    # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L35
+    default: "ghcr.io/kubeflow/kfp-driver:2.4.0"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/api-server:2.3.0-5e9542c
+    upstream-source: ghcr.io/kubeflow/kfp-api-server:2.4.0
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-api-server:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-api-server:2.4.1
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: ghcr.io/kubeflow/kfp-metadata-writer:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-metadata-writer:2.4.1
 requires:
   grpc:
     interface: k8s-service

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: charmedkubeflow/metadata-writer:2.3.0-519bac2
+    upstream-source: ghcr.io/kubeflow/kfp-metadata-writer:2.4.0
 requires:
   grpc:
     interface: k8s-service

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/persistenceagent:2.3.0-0c6ce7c
+    upstream-source: ghcr.io/kubeflow/kfp-persistence-agent:2.4.0
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-persistence-agent:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-persistence-agent:2.4.1
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -59,9 +59,9 @@ def get_settings_from_env(controller_port=None,
     Settings are pulled from the all-caps version of the setting name.  The
     following defaults are used if those environment variables are not set
     to enable backwards compatibility with previous versions of this script:
-        visualization_server_image: gcr.io/ml-pipeline/visualization-server
+        visualization_server_image: ghcr.io/kubeflow/kfp-visualization-server
         visualization_server_tag: value of KFP_VERSION environment variable
-        frontend_image: gcr.io/ml-pipeline/frontend
+        frontend_image: ghcr.io/kubeflow/kfp-frontend
         frontend_tag: value of KFP_VERSION environment variable
         disable_istio_sidecar: Required (no default)
         minio_access_key: Required (no default)
@@ -79,11 +79,11 @@ def get_settings_from_env(controller_port=None,
 
     settings["visualization_server_image"] = \
         visualization_server_image or \
-        os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+        os.environ.get("VISUALIZATION_SERVER_IMAGE", "ghcr.io/kubeflow/kfp-visualization-server")
 
     settings["frontend_image"] = \
         frontend_image or \
-        os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+        os.environ.get("FRONTEND_IMAGE", "ghcr.io/kubeflow/kfp-frontend")
 
     # Look for specific tags for each image first, falling back to
     # previously used KFP_VERSION environment variable for backwards

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -191,7 +191,7 @@ def server_factory(visualization_server_image,
                     "True" or "False"
             }
 
-            # Generate the desired child object(s).
+            # Generate the desired attachment object(s).
             desired_resources += [
                 {
                     "apiVersion": "v1",

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image for kfp-profile-controller
-    upstream-source: ubuntu/python:3.8-20.04_edge
+    upstream-source: python:3.9
   # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
 requires:
   object-storage:

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -54,7 +54,7 @@ K8S_RESOURCE_FILES = [
     "src/templates/secrets.yaml.j2",
 ]
 KFP_DEFAULT_PIPELINE_ROOT = ""
-KFP_IMAGES_VERSION = "2.0.3"  # Remember to change this version also in default-custom-images.json
+KFP_IMAGES_VERSION = "2.4.1"  # Remember to change this version also in default-custom-images.json
 # This service name must be the Service from the mlmd-operator
 # FIXME: leaving it hardcoded now, but we should share this
 # host and port through relation data

--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,4 +1,4 @@
 {
-    "visualization_server": "gcr.io/ml-pipeline/visualization-server:2.0.3",
-    "frontend": "gcr.io/ml-pipeline/frontend:2.0.3"
+    "visualization_server": "ghcr.io/kubeflow/kfp-visualization-server:2.4.1",
+    "frontend": "ghcr.io/kubeflow/kfp-frontend:2.4.1"
 }

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -40,9 +40,9 @@ EXPECTED_ENVIRONMENT = {
     "MINIO_NAMESPACE": MOCK_OBJECT_STORAGE_DATA["namespace"],
     "MINIO_PORT": MOCK_OBJECT_STORAGE_DATA["port"],
     "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
-    "FRONTEND_IMAGE": "gcr.io/ml-pipeline/frontend",
+    "FRONTEND_IMAGE": "ghcr.io/kubeflow/kfp-frontend",
     "FRONTEND_TAG": KFP_IMAGES_VERSION,
-    "VISUALIZATION_SERVER_IMAGE": "gcr.io/ml-pipeline/visualization-server",
+    "VISUALIZATION_SERVER_IMAGE": "ghcr.io/kubeflow/kfp-visualization-server",
     "VISUALIZATION_SERVER_TAG": KFP_IMAGES_VERSION,
 }
 

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/scheduledworkflow:2.3.0-74164db
+    upstream-source: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:2.4.0
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:2.4.1
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: charmedkubeflow/frontend:2.3.0-111c139
+    upstream-source: ghcr.io/kubeflow/kfp-frontend:2.4.0
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,7 +11,8 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    upstream-source: ghcr.io/kubeflow/kfp-frontend:2.4.0
+    # The container's command needs to be updated when switching from upstream image to rock
+    upstream-source: ghcr.io/kubeflow/kfp-frontend:2.4.1
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -43,7 +43,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                         # command should be updated each time we switch from upstream to ROCK image
                         #  - upsstream: "command": "node dist/server.js ../client/ 3000"
                         #  - rock: "command": "node /server/dist/server.js /client/ 3000"
-                        "command": "node /server/dist/server.js /client/ 3000",  # Must be a string
+                        "command": "node dist/server.js ../client/ 3000",
                         "startup": "enabled",
                         # TODO: are these still the correct settings?
                         "environment": {

--- a/charms/kfp-ui/src/templates/auth_manifests.yaml.j2
+++ b/charms/kfp-ui/src/templates/auth_manifests.yaml.j2
@@ -25,6 +25,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: charmedkubeflow/viewer-crd-controller:2.3.0-60337e3
+    upstream-source: ghcr.io/kubeflow/kfp-viewer-crd-controller:2.4.0
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: ghcr.io/kubeflow/kfp-viewer-crd-controller:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-viewer-crd-controller:2.4.1
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: ghcr.io/kubeflow/kfp-visualization-server:2.4.0
+    upstream-source: ghcr.io/kubeflow/kfp-visualization-server:2.4.1
 provides:
   kfp-viz:
     interface: k8s-service

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: charmedkubeflow/visualization-server:2.3.0-a2f7f9e
+    upstream-source: ghcr.io/kubeflow/kfp-visualization-server:2.4.0
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
Upgrade manifests and images to 2.4 according to instructions in the CONTRIBUTING.md file. For `securityContext` changes in upstream manifests, see #675.

Ref KF-6853