### PR TITLE
chore: integrate api-server rock 2.4.0-c10a229

### DIFF
--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/api-server:2.3.0-5e9542c
+    upstream-source: charmedkubeflow/api-server:2.4.0-c10a229
 requires:
   mysql:
     interface: mysql


### PR DESCRIPTION
Integrate the api-server rock 2.4.0-c10a229 in preparation for the 2.4.0 release