### PR TITLE
chore: integrate 2.4.1 rocks

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -52,12 +52,12 @@ options:
   launcher-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L33
-    default: "ghcr.io/kubeflow/kfp-launcher:2.4.1"
+    default: "docker.io/charmedkubeflow/kfp-launcher:2.4.1-0484071"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.4.0/backend/src/v2/compiler/argocompiler/container.go#L35
-    default: "ghcr.io/kubeflow/kfp-driver:2.4.1"
+    default: "docker.io/charmedkubeflow/kfp-driver:2.4.1-1dc7f7d"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -15,7 +15,8 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-api-server:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/api-server:2.4.1-7e49e8b
 requires:
   mysql:
     interface: mysql

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -215,7 +215,7 @@ class KfpApiOperator(CharmBase):
                     "command": f"bash -c '{self._exec_command}'",
                     "startup": "enabled",
                     "environment": self.service_environment,
-                    "user": "_daemon_", # This is needed only for rocks
+                    "user": "_daemon_",  # This is needed only for rocks
                     "on-check-failure": {"kfp-api-up": "restart"},
                 }
             },

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -215,6 +215,7 @@ class KfpApiOperator(CharmBase):
                     "command": f"bash -c '{self._exec_command}'",
                     "startup": "enabled",
                     "environment": self.service_environment,
+                    "user": "_daemon_", # This is needed only for rocks
                     "on-check-failure": {"kfp-api-up": "restart"},
                 }
             },

--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -13,7 +13,8 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for KFP Metadata Writer
-    upstream-source: ghcr.io/kubeflow/kfp-metadata-writer:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/metadata-writer:2.4.1-82e23c1
 requires:
   grpc:
     interface: k8s-service

--- a/charms/kfp-metadata-writer/src/components/pebble_component.py
+++ b/charms/kfp-metadata-writer/src/components/pebble_component.py
@@ -61,6 +61,7 @@ class KfpMetadataWriterPebbleService(PebbleServiceComponent):
                         "summary": "Entry point for kfp-metadata-writer oci-image",
                         "command": "python3 -u /kfp/metadata_writer/metadata_writer.py",
                         "startup": "enabled",
+                        "user": "_daemon_", # This is needed only for rocks
                         "environment": environment,
                     }
                 },

--- a/charms/kfp-metadata-writer/src/components/pebble_component.py
+++ b/charms/kfp-metadata-writer/src/components/pebble_component.py
@@ -61,7 +61,7 @@ class KfpMetadataWriterPebbleService(PebbleServiceComponent):
                         "summary": "Entry point for kfp-metadata-writer oci-image",
                         "command": "python3 -u /kfp/metadata_writer/metadata_writer.py",
                         "startup": "enabled",
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                         "environment": environment,
                     }
                 },

--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -11,7 +11,8 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-persistence-agent:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/persistenceagent:2.4.1-5aa97b7
 requires:
   kfp-api:
     interface: k8s-service

--- a/charms/kfp-persistence/src/components/pebble_components.py
+++ b/charms/kfp-persistence/src/components/pebble_components.py
@@ -67,7 +67,7 @@ class PersistenceAgentPebbleService(PebbleServiceComponent):
                         "summary": "persistenceagent service",
                         "command": " ".join(command),
                         "startup": "enabled",
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                         "environment": self._environment,
                     }
                 },

--- a/charms/kfp-persistence/src/components/pebble_components.py
+++ b/charms/kfp-persistence/src/components/pebble_components.py
@@ -67,6 +67,7 @@ class PersistenceAgentPebbleService(PebbleServiceComponent):
                         "summary": "persistenceagent service",
                         "command": " ".join(command),
                         "startup": "enabled",
+                        "user": "_daemon_", # This is needed only for rocks
                         "environment": self._environment,
                     }
                 },

--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -4,7 +4,7 @@
 options:
   custom_images:
     type: string
-    # defaults should match src/defaults-custom-images.json
+    # default keys should match src/defaults-custom-images.json
     default: | 
       visualization_server : ''
       frontend : ''

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -11,8 +11,9 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image for kfp-profile-controller
-    upstream-source: python:3.9
-  # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION in charm.py.  That variable must also be updated
+    upstream-source: docker.io/ubuntu/python:3.12-24.04_stable
+    # NOTE: If bumping KFP version, see also KFP_IMAGES_VERSION and the images in default-custom-images.json
+    # in charm.py. Those must also be updated.
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,4 +1,4 @@
 {
-    "visualization_server": "ghcr.io/kubeflow/kfp-visualization-server:2.4.1",
-    "frontend": "ghcr.io/kubeflow/kfp-frontend:2.4.1"
+    "visualization_server": "docker.io/charmedkubeflow/visualization-server:2.4.1-f7dc003",
+    "frontend": "docker.io/charmedkubeflow/frontend:2.4.1-5984eac"
 }

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -40,10 +40,10 @@ EXPECTED_ENVIRONMENT = {
     "MINIO_NAMESPACE": MOCK_OBJECT_STORAGE_DATA["namespace"],
     "MINIO_PORT": MOCK_OBJECT_STORAGE_DATA["port"],
     "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
-    "FRONTEND_IMAGE": "ghcr.io/kubeflow/kfp-frontend",
-    "FRONTEND_TAG": KFP_IMAGES_VERSION,
-    "VISUALIZATION_SERVER_IMAGE": "ghcr.io/kubeflow/kfp-visualization-server",
-    "VISUALIZATION_SERVER_TAG": KFP_IMAGES_VERSION,
+    "FRONTEND_IMAGE": "docker.io/charmedkubeflow/frontend",
+    "FRONTEND_TAG": "2.4.1-5984eac",
+    "VISUALIZATION_SERVER_IMAGE": "docker.io/charmedkubeflow/visualization-server",
+    "VISUALIZATION_SERVER_TAG": "2.4.1-f7dc003",
 }
 
 

--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -11,7 +11,8 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/scheduledworkflow:2.4.1-3a4780e
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -49,7 +49,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         ' --namespace=""'
                         f" --logLevel={self.log_level}",
                         "environment": self.environment,
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                     }
                 },
             }

--- a/charms/kfp-schedwf/src/components/pebble_component.py
+++ b/charms/kfp-schedwf/src/components/pebble_component.py
@@ -49,6 +49,7 @@ class KfpSchedwfPebbleService(PebbleServiceComponent):
                         ' --namespace=""'
                         f" --logLevel={self.log_level}",
                         "environment": self.environment,
+                        "user": "_daemon_", # This is needed only for rocks
                     }
                 },
             }

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -11,8 +11,8 @@ resources:
   ml-pipeline-ui:
     type: oci-image
     description: OCI image for ml-pipeline-ui
-    # The container's command needs to be updated when switching from upstream image to rock
-    upstream-source: ghcr.io/kubeflow/kfp-frontend:2.4.1
+    # The container's command and `user` need to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/frontend:2.4.1-5984eac
 requires:
   object-storage:
     interface: object-storage

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -43,8 +43,9 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                         # command should be updated each time we switch from upstream image to rock
                         #  - upsstream: "command": "node dist/server.js ../client/ 3000"
                         #  - rock: "command": "node /server/dist/server.js /client/ 3000"
-                        "command": "node dist/server.js ../client/ 3000",
+                        "command": "node /server/dist/server.js /client/ 3000",
                         "startup": "enabled",
+                        "user": "_daemon_", # This is needed only for rocks
                         # TODO: are these still the correct settings?
                         "environment": {
                             "ALLOW_CUSTOM_VISUALIZATIONS": str(

--- a/charms/kfp-ui/src/components/pebble_components.py
+++ b/charms/kfp-ui/src/components/pebble_components.py
@@ -45,7 +45,7 @@ class MlPipelineUiPebbleService(PebbleServiceComponent):
                         #  - rock: "command": "node /server/dist/server.js /client/ 3000"
                         "command": "node /server/dist/server.js /client/ 3000",
                         "startup": "enabled",
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                         # TODO: are these still the correct settings?
                         "environment": {
                             "ALLOW_CUSTOM_VISUALIZATIONS": str(

--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -12,7 +12,8 @@ resources:
   kfp-viewer-image:
     type: oci-image
     description: OCI image for KFP Viewer
-    upstream-source: ghcr.io/kubeflow/kfp-viewer-crd-controller:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/viewer-crd-controller:2.4.1-a9524a2
 requires:
   logging:
     interface: loki_push_api

--- a/charms/kfp-viewer/src/components/pebble_component.py
+++ b/charms/kfp-viewer/src/components/pebble_component.py
@@ -46,6 +46,7 @@ class KfpViewerPebbleService(PebbleServiceComponent):
                         ),
                         "startup": "enabled",
                         "environment": self.environment,
+                        "user": "_daemon_", # This is needed only for rocks
                     }
                 },
             }

--- a/charms/kfp-viewer/src/components/pebble_component.py
+++ b/charms/kfp-viewer/src/components/pebble_component.py
@@ -46,7 +46,7 @@ class KfpViewerPebbleService(PebbleServiceComponent):
                         ),
                         "startup": "enabled",
                         "environment": self.environment,
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                     }
                 },
             }

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -11,7 +11,8 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
-    upstream-source: ghcr.io/kubeflow/kfp-visualization-server:2.4.1
+    # The container's `user` needs to be updated when switching from upstream image to rock
+    upstream-source: docker.io/charmedkubeflow/visualization-server:2.4.1-f7dc003
 provides:
   kfp-viz:
     interface: k8s-service

--- a/charms/kfp-viz/src/components/pebble_components.py
+++ b/charms/kfp-viz/src/components/pebble_components.py
@@ -21,6 +21,7 @@ class KfpVizPebbleService(PebbleServiceComponent):
                         "command": "python3 server.py",  # Must be a string
                         "startup": "enabled",
                         "on-check-failure": {"kfp-viz-up": "restart"},
+                        "user": "_daemon_", # This is needed only for rocks
                     }
                 },
                 "checks": {

--- a/charms/kfp-viz/src/components/pebble_components.py
+++ b/charms/kfp-viz/src/components/pebble_components.py
@@ -21,7 +21,7 @@ class KfpVizPebbleService(PebbleServiceComponent):
                         "command": "python3 server.py",  # Must be a string
                         "startup": "enabled",
                         "on-check-failure": {"kfp-viz-up": "restart"},
-                        "user": "_daemon_", # This is needed only for rocks
+                        "user": "_daemon_",  # This is needed only for rocks
                     }
                 },
                 "checks": {


### PR DESCRIPTION
* Integrate 2.4.1 rocks
* Update the container's `user` field in the each pebble plan according to canonical/kfp-operators#675
* Update contributing.md file

Close https://warthogs.atlassian.net/browse/KF-6938 (and all relevant integrate tasks)

The rocks integrated are from those jobs:
* viewer crd https://github.com/canonical/pipelines-rocks/actions/runs/13651064805/job/38160407837
* driver https://github.com/canonical/pipelines-rocks/actions/runs/13651225515/job/38160725716
* metadata-writer https://github.com/canonical/pipelines-rocks/actions/runs/13651117698/job/38160575489
* persistenceagent https://github.com/canonical/pipelines-rocks/actions/runs/13651108638/job/38160292729
* frontend https://github.com/canonical/pipelines-rocks/actions/runs/13651097370/job/38160646807#step:7:14
* launcher https://github.com/canonical/pipelines-rocks/actions/runs/13651090202/job/38160320623#step:7:14
* scheduledworkflow https://github.com/canonical/pipelines-rocks/actions/runs/13651083317/job/38160423244#step:7:14
* update profile-controller to 3.12 since this is coming in upstream too https://github.com/kubeflow/pipelines/pull/11669/files
* api-server https://github.com/canonical/pipelines-rocks/actions/runs/13657696257/job/38182074309#step:7:14
* viz server https://github.com/canonical/pipelines-rocks/actions/runs/13671346731/job/38223151950
