### PR TITLE
[KF-7159] bug: terraform module  variable is not set in 2.3 track

### DIFF
--- a/charms/kfp-api/terraform/variables.tf
+++ b/charms/kfp-api/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-metadata-writer/terraform/variables.tf
+++ b/charms/kfp-metadata-writer/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-persistence/terraform/variables.tf
+++ b/charms/kfp-persistence/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-profile-controller/terraform/variables.tf
+++ b/charms/kfp-profile-controller/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-schedwf/terraform/variables.tf
+++ b/charms/kfp-schedwf/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-ui/terraform/variables.tf
+++ b/charms/kfp-ui/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-viewer/terraform/variables.tf
+++ b/charms/kfp-viewer/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {

--- a/charms/kfp-viz/terraform/variables.tf
+++ b/charms/kfp-viz/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "2.3/stable"
 }
 
 variable "config" {


### PR DESCRIPTION
fixes #685 

I realized this was actually missing only in track 2.3, and not in 2.2, e.g. see [here](https://github.com/canonical/kfp-operators/blob/track/2.2/charms/kfp-api/terraform/variables.tf#L10)