### PR TITLE
fix(workaround): set constraints to setuptools-scm to avoid install loops

### DIFF
--- a/charms/kfp-api/charmcraft.yaml
+++ b/charms/kfp-api/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-api/constraints.txt
+++ b/charms/kfp-api/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-metadata-writer/charmcraft.yaml
+++ b/charms/kfp-metadata-writer/charmcraft.yaml
@@ -34,6 +34,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-metadata-writer/constraints.txt
+++ b/charms/kfp-metadata-writer/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-persistence/charmcraft.yaml
+++ b/charms/kfp-persistence/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-persistence/constraints.txt
+++ b/charms/kfp-persistence/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-profile-controller/charmcraft.yaml
+++ b/charms/kfp-profile-controller/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-profile-controller/constraints.txt
+++ b/charms/kfp-profile-controller/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-schedwf/charmcraft.yaml
+++ b/charms/kfp-schedwf/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-schedwf/constraints.txt
+++ b/charms/kfp-schedwf/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-ui/charmcraft.yaml
+++ b/charms/kfp-ui/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-ui/constraints.txt
+++ b/charms/kfp-ui/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-viewer/charmcraft.yaml
+++ b/charms/kfp-viewer/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-viewer/constraints.txt
+++ b/charms/kfp-viewer/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/kfp-viz/charmcraft.yaml
+++ b/charms/kfp-viz/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/kfp-viz/constraints.txt
+++ b/charms/kfp-viz/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
Due to python/importlib_metadata#516, we need to set up constaints
to the `setuptools-scm` to avoid install loops for these charms dependencies,
as recommended by the charmcraft team (see https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428).

Fixes #293
