### PR TITLE
chore(ci): Remove SDK matrix in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,6 +277,4 @@ jobs:
       # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        with:
-          artifact-prefix: ${{ matrix.sdk }}
         if: failure() || cancelled()


### PR DESCRIPTION
This PR removes the {matrix-sdk} matrix completely in the `ci.yaml` file