### PR TITLE
feat: Add Grafana dashboard for `kfp-api`

### DIFF
--- a/charms/kfp-api/requirements-unit.txt
+++ b/charms/kfp-api/requirements-unit.txt
@@ -30,7 +30,7 @@ charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
-cosl==0.0.45
+cosl==0.1.0
     # via -r requirements.in
 coverage==7.6.1
     # via -r requirements-unit.in

--- a/charms/kfp-api/requirements.in
+++ b/charms/kfp-api/requirements.in
@@ -5,4 +5,5 @@ oci-image
 serialized-data-interface
 tenacity
 # from prometheus_k8s.v0.prometheus_scrape.py
-cosl
+# Pinning due to https://github.com/canonical/bundle-kubeflow/issues/1260
+cosl>=0.0.48

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -30,7 +30,7 @@ charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 cryptography==44.0.0
     # via paramiko

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -30,7 +30,7 @@ charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
-cosl==0.0.50
+cosl==0.0.45
     # via -r requirements.in
 cryptography==44.0.0
     # via paramiko

--- a/charms/kfp-api/requirements.txt
+++ b/charms/kfp-api/requirements.txt
@@ -30,7 +30,7 @@ charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
-cosl==0.0.45
+cosl==0.1.0
     # via -r requirements.in
 cryptography==44.0.0
     # via paramiko

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -17,6 +17,7 @@ from charmed_kubeflow_chisme.kubernetes import (
 )
 from charmed_kubeflow_chisme.pebble import update_layer
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
@@ -140,6 +141,9 @@ class KfpApiOperator(CharmBase):
                 }
             ],
         )
+
+        self.dashboard_provider = GrafanaDashboardProvider(self)
+        
         self._logging = LogForwarder(charm=self)
 
     @property

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -143,7 +143,7 @@ class KfpApiOperator(CharmBase):
         )
 
         self.dashboard_provider = GrafanaDashboardProvider(self)
-        
+
         self._logging = LogForwarder(charm=self)
 
     @property


### PR DESCRIPTION
Closes #698.

Note that we're also pinning the version of `cosl>=0.0.48` due to https://github.com/canonical/bundle-kubeflow/issues/1260