### PR TITLE
chore: upgrade Ubuntu for newer test charm bases

### DIFF
--- a/charms/kfp-metadata-writer/requirements-fmt.txt
+++ b/charms/kfp-metadata-writer/requirements-fmt.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==24.8.0
+black==25.1.0
     # via -r requirements-fmt.in
-click==8.1.7
+click==8.2.1
     # via black
-isort==5.13.2
+isort==6.0.1
     # via -r requirements-fmt.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
-packaging==24.2
+packaging==25.0
     # via black
 pathspec==0.12.1
     # via black
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via black

--- a/charms/kfp-metadata-writer/requirements-integration.txt
+++ b/charms/kfp-metadata-writer/requirements-integration.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.5.2
+anyio==4.9.0
     # via httpx
 asttokens==3.0.0
     # via stack-data
-attrs==24.2.0
+attrs==25.3.0
     # via jsonschema
-backcall==0.2.0
-    # via ipython
-bcrypt==4.2.1
+backports-datetime-fromisoformat==2.0.3
+    # via juju
+bcrypt==4.3.0
     # via paramiko
-cachetools==5.5.0
+cachetools==5.5.2
     # via google-auth
-certifi==2024.8.30
+certifi==2025.6.15
     # via
     #   httpcore
     #   httpx
@@ -28,23 +28,23 @@ cffi==1.17.1
     #   pynacl
 charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via requests
-cryptography==44.0.0
+cryptography==45.0.4
     # via paramiko
-decorator==5.1.1
+decorator==5.2.1
     # via
     #   ipdb
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-executing==2.1.0
+executing==2.2.0
     # via stack-data
-google-auth==2.36.0
+google-auth==2.40.3
     # via kubernetes
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.27.2
     # via
@@ -57,65 +57,71 @@ idna==3.10
     #   anyio
     #   httpx
     #   requests
-iniconfig==2.0.0
+importlib-metadata==8.7.0
+    # via
+    #   opentelemetry-api
+    #   ops
+iniconfig==2.1.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.3
+ipython==9.3.0
     # via ipdb
+ipython-pygments-lexers==1.1.1
+    # via ipython
 jedi==0.19.2
     # via ipython
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   charmed-kubeflow-chisme
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.6.0.0
+juju==3.6.1.2
     # via
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.6
+lightkube==0.17.1
     # via charmed-kubeflow-chisme
-lightkube-models==1.31.1.8
+lightkube-models==1.33.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via typing-inspect
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.1
+opentelemetry-api==1.34.1
+    # via ops
+ops==2.22.0
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.2
+packaging==25.0
     # via
     #   juju
     #   pytest
-paramiko==3.5.0
+paramiko==3.5.1
     # via juju
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-pickleshare==0.7.5
-    # via ipython
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.51
     # via ipython
-protobuf==5.29.1
+protobuf==6.31.1
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -126,12 +132,15 @@ pyasn1==0.6.1
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22
     # via cffi
-pygments==2.18.0
-    # via ipython
+pygments==2.19.2
+    # via
+    #   ipython
+    #   ipython-pygments-lexers
+    #   pytest
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -140,22 +149,20 @@ pynacl==1.5.0
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
-    # via
-    #   juju
-    #   macaroonbakery
+    # via macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.3.4
+pytest==8.4.1
     # via
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.38.0
+pytest-operator==0.42.0
     # via -r requirements-integration.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.2
+pytz==2025.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
@@ -165,7 +172,7 @@ pyyaml==6.0.2
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-requests==2.32.3
+requests==2.32.4
     # via
     #   hvac
     #   kubernetes
@@ -174,11 +181,11 @@ requests==2.32.3
     #   serialized-data-interface
 requests-oauthlib==2.0.0
     # via kubernetes
-rsa==4.9
+rsa==4.9.1
     # via google-auth
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.14
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.8
+ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
@@ -194,7 +201,7 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tenacity==9.0.0
+tenacity==9.1.2
     # via charmed-kubeflow-chisme
 toposort==1.10
     # via juju
@@ -202,13 +209,15 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
+    #   anyio
     #   juju
+    #   opentelemetry-api
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.3
+urllib3==2.5.0
     # via
     #   kubernetes
     #   requests
@@ -218,5 +227,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==13.1
+websockets==15.0.1
     # via juju
+zipp==3.23.0
+    # via importlib-metadata

--- a/charms/kfp-metadata-writer/requirements-lint.txt
+++ b/charms/kfp-metadata-writer/requirements-lint.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==24.8.0
+black==25.1.0
     # via -r requirements-lint.in
-click==8.1.7
+click==8.2.1
     # via black
-codespell==2.3.0
+codespell==2.4.1
     # via -r requirements-lint.in
 flake8==7.0.0
     # via
@@ -20,19 +20,19 @@ flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.13.2
+isort==6.0.1
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
-packaging==24.2
+packaging==25.0
     # via black
 pathspec==0.12.1
     # via black
-pep8-naming==0.14.1
+pep8-naming==0.15.1
     # via -r requirements-lint.in
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via black
 pycodestyle==2.11.1
     # via flake8

--- a/charms/kfp-metadata-writer/requirements-unit.txt
+++ b/charms/kfp-metadata-writer/requirements-unit.txt
@@ -8,23 +8,27 @@ annotated-types==0.7.0
     # via
     #   -r requirements.txt
     #   pydantic
-anyio==4.5.2
+anyio==4.9.0
     # via
     #   -r requirements.txt
     #   httpx
-attrs==24.2.0
+attrs==25.3.0
     # via
     #   -r requirements.txt
     #   jsonschema
-bcrypt==4.2.1
+backports-datetime-fromisoformat==2.0.3
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.3.0
     # via
     #   -r requirements.txt
     #   paramiko
-cachetools==5.5.0
+cachetools==5.5.2
     # via
     #   -r requirements.txt
     #   google-auth
-certifi==2024.8.30
+certifi==2025.6.15
     # via
     #   -r requirements.txt
     #   httpcore
@@ -38,15 +42,15 @@ cffi==1.17.1
     #   pynacl
 charmed-kubeflow-chisme==0.4.11
     # via -r requirements.txt
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
     #   -r requirements.txt
     #   requests
-cosl==0.0.45
+cosl==1.0.0
     # via -r requirements.txt
-coverage==7.6.1
+coverage==7.9.1
     # via -r requirements-unit.in
-cryptography==44.0.0
+cryptography==45.0.4
     # via
     #   -r requirements.txt
     #   paramiko
@@ -54,15 +58,15 @@ deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-google-auth==2.36.0
+google-auth==2.40.3
     # via
     #   -r requirements.txt
     #   kubernetes
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via
     #   -r requirements.txt
     #   httpx
@@ -81,9 +85,14 @@ idna==3.10
     #   anyio
     #   httpx
     #   requests
-iniconfig==2.0.0
+importlib-metadata==8.7.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-api
+    #   ops
+iniconfig==2.1.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -91,7 +100,7 @@ jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-juju==3.6.0.0
+juju==3.6.1.2
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -99,12 +108,11 @@ kubernetes==30.1.0
     # via
     #   -r requirements.txt
     #   juju
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-    #   cosl
-lightkube-models==1.31.1.8
+lightkube-models==1.33.1.8
     # via
     #   -r requirements.txt
     #   lightkube
@@ -112,20 +120,24 @@ macaroonbakery==1.3.4
     # via
     #   -r requirements.txt
     #   juju
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -r requirements.txt
     #   jinja2
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   -r requirements.txt
     #   typing-inspect
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r requirements.txt
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.1
+opentelemetry-api==1.34.1
+    # via
+    #   -r requirements.txt
+    #   ops
+ops==2.22.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.txt
@@ -136,18 +148,18 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements.txt
     #   juju
     #   pytest
-paramiko==3.5.0
+paramiko==3.5.1
     # via
     #   -r requirements.txt
     #   juju
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-protobuf==5.29.1
+protobuf==6.31.1
     # via
     #   -r requirements.txt
     #   macaroonbakery
@@ -157,7 +169,7 @@ pyasn1==0.6.1
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   -r requirements.txt
     #   google-auth
@@ -165,14 +177,16 @@ pycparser==2.22
     # via
     #   -r requirements.txt
     #   cffi
-pydantic==2.6.4
+pydantic==2.11.7
     # via
     #   -r requirements.txt
     #   cosl
-pydantic-core==2.16.3
+pydantic-core==2.33.2
     # via
     #   -r requirements.txt
     #   pydantic
+pygments==2.19.2
+    # via pytest
 pymacaroons==0.13.0
     # via
     #   -r requirements.txt
@@ -186,23 +200,22 @@ pynacl==1.5.0
 pyrfc3339==1.1
     # via
     #   -r requirements.txt
-    #   juju
     #   macaroonbakery
 pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==8.3.4
+pytest==8.4.1
     # via
     #   -r requirements-unit.in
     #   pytest-mock
-pytest-mock==3.14.0
+pytest-mock==3.14.1
     # via -r requirements-unit.in
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   kubernetes
-pytz==2024.2
+pytz==2025.2
     # via
     #   -r requirements.txt
     #   pyrfc3339
@@ -216,7 +229,7 @@ pyyaml==6.0.2
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements.txt
     #   hvac
@@ -228,15 +241,15 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements.txt
     #   kubernetes
-rsa==4.9
+rsa==4.9.1
     # via
     #   -r requirements.txt
     #   google-auth
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.14
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.8
+ruamel-yaml-clib==0.2.12
     # via
     #   -r requirements.txt
     #   ruamel-yaml
@@ -256,7 +269,7 @@ sniffio==1.3.1
     #   -r requirements.txt
     #   anyio
     #   httpx
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -265,19 +278,26 @@ toposort==1.10
     # via
     #   -r requirements.txt
     #   juju
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -r requirements.txt
+    #   anyio
     #   cosl
     #   juju
+    #   opentelemetry-api
     #   pydantic
     #   pydantic-core
     #   typing-inspect
+    #   typing-inspection
 typing-inspect==0.9.0
     # via
     #   -r requirements.txt
     #   juju
-urllib3==2.2.3
+typing-inspection==0.4.1
+    # via
+    #   -r requirements.txt
+    #   pydantic
+urllib3==2.5.0
     # via
     #   -r requirements.txt
     #   kubernetes
@@ -287,7 +307,11 @@ websocket-client==1.8.0
     #   -r requirements.txt
     #   kubernetes
     #   ops
-websockets==13.1
+websockets==15.0.1
     # via
     #   -r requirements.txt
     #   juju
+zipp==3.23.0
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata

--- a/charms/kfp-metadata-writer/requirements.in
+++ b/charms/kfp-metadata-writer/requirements.in
@@ -3,12 +3,7 @@
 charmed-kubeflow-chisme>=0.4.11
 lightkube
 ops
-# pydantic>=2.7 requires rustc v1.76 or newer,
-# which is not available in the base OS this charm has at the moment (Ubuntu 20.04).
-# To avoid build-time errors, pydantic has to be pinned to a version that can be built
-# with the rustc version that the OS can provide.
-# Remove this pin when the base OS can install rustc v1.76 or newer.
-pydantic>=2.6,<2.7
+pydantic
 serialized-data-interface
 # from loki_k8s.v1.loki_push_api.py
 cosl

--- a/charms/kfp-metadata-writer/requirements.txt
+++ b/charms/kfp-metadata-writer/requirements.txt
@@ -6,15 +6,17 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.5.2
+anyio==4.9.0
     # via httpx
-attrs==24.2.0
+attrs==25.3.0
     # via jsonschema
-bcrypt==4.2.1
+backports-datetime-fromisoformat==2.0.3
+    # via juju
+bcrypt==4.3.0
     # via paramiko
-cachetools==5.5.0
+cachetools==5.5.2
     # via google-auth
-certifi==2024.8.30
+certifi==2025.6.15
     # via
     #   httpcore
     #   httpx
@@ -26,19 +28,19 @@ cffi==1.17.1
     #   pynacl
 charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via requests
-cosl==0.0.45
+cosl==1.0.0
     # via -r requirements.in
-cryptography==44.0.0
+cryptography==45.0.4
     # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-google-auth==2.36.0
+google-auth==2.40.3
     # via kubernetes
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.27.2
     # via
@@ -51,32 +53,37 @@ idna==3.10
     #   anyio
     #   httpx
     #   requests
-jinja2==3.1.4
+importlib-metadata==8.7.0
+    # via
+    #   opentelemetry-api
+    #   ops
+jinja2==3.1.6
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.6.0.0
+juju==3.6.1.2
     # via charmed-kubeflow-chisme
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-    #   cosl
-lightkube-models==1.31.1.8
+lightkube-models==1.33.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via typing-inspect
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.1
+opentelemetry-api==1.34.1
+    # via ops
+ops==2.22.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -84,26 +91,26 @@ ops==2.17.1
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.2
+packaging==25.0
     # via juju
-paramiko==3.5.0
+paramiko==3.5.1
     # via juju
-protobuf==5.29.1
+protobuf==6.31.1
     # via macaroonbakery
 pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.6.4
+pydantic==2.11.7
     # via
     #   -r requirements.in
     #   cosl
-pydantic-core==2.16.3
+pydantic-core==2.33.2
     # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -113,14 +120,12 @@ pynacl==1.5.0
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
-    # via
-    #   juju
-    #   macaroonbakery
+    # via macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.2
+pytz==2025.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
@@ -130,7 +135,7 @@ pyyaml==6.0.2
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.32.3
+requests==2.32.4
     # via
     #   hvac
     #   kubernetes
@@ -139,11 +144,11 @@ requests==2.32.3
     #   serialized-data-interface
 requests-oauthlib==2.0.0
     # via kubernetes
-rsa==4.9
+rsa==4.9.1
     # via google-auth
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.14
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.8
+ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via
@@ -159,22 +164,27 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   charmed-kubeflow-chisme
     #   cosl
 toposort==1.10
     # via juju
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
+    #   anyio
     #   cosl
     #   juju
+    #   opentelemetry-api
     #   pydantic
     #   pydantic-core
     #   typing-inspect
+    #   typing-inspection
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.3
+typing-inspection==0.4.1
+    # via pydantic
+urllib3==2.5.0
     # via
     #   kubernetes
     #   requests
@@ -182,5 +192,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==13.1
+websockets==15.0.1
     # via juju
+zipp==3.23.0
+    # via importlib-metadata

--- a/charms/kfp-ui/tests/integration/bundle.yaml.j2
+++ b/charms/kfp-ui/tests/integration/bundle.yaml.j2
@@ -3,19 +3,19 @@ applications:
   kfp-api:
     charm: {{ kfp_api_charm }}
     channel: {{ kfp_api_channel }}
-    base: ubuntu@20.04/stable
+    base: ubuntu@24.04/stable
     scale: 1
     trust: {{ kfp_api_trust }}
   kfp-viz:
     charm: {{ kfp_viz_charm }}
     channel: {{ kfp_viz_channel }}
-    base: ubuntu@20.04/stable
+    base: ubuntu@24.04/stable
     scale: 1
     trust: {{ kfp_viz_trust }}
   minio:
     charm: {{ minio_charm }}
     channel: {{ minio_channel }}
-    base: ubuntu@20.04/stable
+    base: ubuntu@24.04/stable
     scale: 1
     {% if minio_config %}
     options:


### PR DESCRIPTION
## Description

This pull request addressed the note in the description of [this other pull request](https://github.com/canonical/kfp-operators/pull/723). See the latter for details.

Moreover, this pull request unpins a direct sub-charm dependency since its upgrades are no longer problematic with newer Ubuntu versions.