### PR TITLE
fix: Change dump-charm-debug-artifacts on failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,7 +207,7 @@ jobs:
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         with:
           artifact-prefix: ${{ matrix.charm }}
-        if: always()
+        if: failure()
 
   test-bundle:
     name: Test the bundle


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1341

This PR backports a change to only run the `dump-charm-debug-artifacts` action on failure in order to save time.