### PR TITLE
fix: Retry on getting `ConfigMap` in `kubeflow-profile-controller` integration tests

### DIFF
--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -66,7 +66,7 @@ def wait_for_configmap(client: lightkube.Client, name: str, namespace: str) -> C
     for attempt in RETRY_FOR_ONE_MINUTE:
         with attempt:
             return client.get(res=ConfigMap, name=name, namespace=namespace)
-    raise TimeoutError(f"ConfigMap {name} not present.")
+    raise TimeoutError(f"ConfigMap {name} in namespace {namespace} not present.")
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Closes #795

This PR updates `charms/kfp-profile-controller/tests/integration/test_charm.py` to `retry` while trying to receive the `kfp-launcher` `ConfigMap` in the profile namespace. This is because the execution of the `sync` function in `sync.py` isn't guaranteed to be finished when the charm is idle & active.

The reasoning behind this change is explained [here](https://github.com/canonical/kfp-operators/issues/795#issuecomment-3582146764).