### PR TITLE
backport: Pin charm base to 24.04 in Terraform module and release-charm actions (#792)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
       charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   integration:
-    name: Integration tests (microk8s)
+    name: Integration tests
     needs:
       - build
     runs-on: ubuntu-24.04

--- a/charms/kfp-api/terraform/README.md
+++ b/charms/kfp-api/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-api/terraform/main.tf
+++ b/charms/kfp-api/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_api" {
   charm {
     name     = "kfp-api"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-api/terraform/variables.tf
+++ b/charms/kfp-api/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-api"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-metadata-writer/terraform/README.md
+++ b/charms/kfp-metadata-writer/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-metadata-writer/terraform/main.tf
+++ b/charms/kfp-metadata-writer/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_metadata_writer" {
   charm {
     name     = "kfp-metadata-writer"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-metadata-writer/terraform/variables.tf
+++ b/charms/kfp-metadata-writer/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-metadata-writer"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-persistence/terraform/README.md
+++ b/charms/kfp-persistence/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-persistence/terraform/main.tf
+++ b/charms/kfp-persistence/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_persistence" {
   charm {
     name     = "kfp-persistence"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-persistence/terraform/variables.tf
+++ b/charms/kfp-persistence/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-persistence"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-profile-controller/terraform/README.md
+++ b/charms/kfp-profile-controller/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-profile-controller/terraform/main.tf
+++ b/charms/kfp-profile-controller/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_profile_controller" {
   charm {
     name     = "kfp-profile-controller"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-profile-controller/terraform/variables.tf
+++ b/charms/kfp-profile-controller/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-profile-controller"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-schedwf/terraform/README.md
+++ b/charms/kfp-schedwf/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-schedwf/terraform/main.tf
+++ b/charms/kfp-schedwf/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_schedwf" {
   charm {
     name     = "kfp-schedwf"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-schedwf/terraform/variables.tf
+++ b/charms/kfp-schedwf/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-schedwf"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-ui/terraform/README.md
+++ b/charms/kfp-ui/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-ui/terraform/main.tf
+++ b/charms/kfp-ui/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_ui" {
   charm {
     name     = "kfp-ui"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-ui/terraform/variables.tf
+++ b/charms/kfp-ui/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-ui"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-viewer/terraform/README.md
+++ b/charms/kfp-viewer/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-viewer/terraform/main.tf
+++ b/charms/kfp-viewer/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_viewer" {
   charm {
     name     = "kfp-viewer"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-viewer/terraform/variables.tf
+++ b/charms/kfp-viewer/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-viewer"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/kfp-viz/terraform/README.md
+++ b/charms/kfp-viz/terraform/README.md
@@ -10,6 +10,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kfp-viz/terraform/main.tf
+++ b/charms/kfp-viz/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kfp_viz" {
   charm {
     name     = "kfp-viz"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kfp-viz/terraform/variables.tf
+++ b/charms/kfp-viz/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kfp-viz"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
This PR is a backport of #792 to `track/2.5`