### PR TITLE
fix: bump Rust version to 1.92.0 (#817)

### DIFF
--- a/charms/kfp-api/charmcraft.yaml
+++ b/charms/kfp-api/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-metadata-writer/charmcraft.yaml
+++ b/charms/kfp-metadata-writer/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-persistence/charmcraft.yaml
+++ b/charms/kfp-persistence/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-profile-controller/charmcraft.yaml
+++ b/charms/kfp-profile-controller/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-schedwf/charmcraft.yaml
+++ b/charms/kfp-schedwf/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-ui/charmcraft.yaml
+++ b/charms/kfp-ui/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-viewer/charmcraft.yaml
+++ b/charms/kfp-viewer/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/kfp-viz/charmcraft.yaml
+++ b/charms/kfp-viz/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
Refs https://github.com/canonical/bundle-kubeflow/issues/1381
Backports #817 