### PR TITLE
fix: use correct policy in profiles-controller itests

### DIFF
--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -188,17 +188,16 @@ async def test_insecure_authorization_policy_is_missing(
     lightkube_client: lightkube.Client, profile: str
 ):
     """Test if the previous sidecar AuthorizationPolicy is not present in Profile."""
-    policy_name = ""
     logger.info(
         'Checking  if AuthorizationPolicy "%s" is not present in Profile "%s"',
-        policy_name,
+        SIDECAR_AP_NAME,
         profile,
     )
 
     with pytest.raises(ApiError) as excinfo:
         lightkube_client.get(
             AuthorizationPolicy,
-            name=policy_name,
+            name=SIDECAR_AP_NAME,
             namespace=profile,
         )
 


### PR DESCRIPTION
Follow-up of https://github.com/canonical/kfp-operators/pull/820

The previous PR introduced a small bug in the integration tests, in which we were not checking for the absence of the correct AuthorizationPolicy