### PR TITLE
chore: update terraform outputs with ambient relations

### DIFF
--- a/charms/kfp-api/terraform/outputs.tf
+++ b/charms/kfp-api/terraform/outputs.tf
@@ -4,18 +4,22 @@ output "app_name" {
 
 output "provides" {
   value = {
-    kfp_api           = "kfp-api",
-    metrics_endpoint  = "metrics-endpoint",
     grafana_dashboard = "grafana-dashboard",
+    kfp_api           = "kfp-api",
+    kfp_api_grpc      = "kfp-api-grpc",
+    metrics_endpoint  = "metrics-endpoint",
+    provide_cmr_mesh  = "provide-cmr-mesh"
   }
 }
 
 output "requires" {
   value = {
-    mysql          = "mysql",
-    relational_db  = "relational-db",
-    object_storage = "object-storage",
-    kfp_viz        = "kfp-viz",
-    logging        = "logging",
+    kfp_viz          = "kfp-viz",
+    logging          = "logging",
+    mysql            = "mysql",
+    object_storage   = "object-storage",
+    relational_db    = "relational-db",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh"
   }
 }

--- a/charms/kfp-persistence/terraform/outputs.tf
+++ b/charms/kfp-persistence/terraform/outputs.tf
@@ -3,12 +3,17 @@ output "app_name" {
 }
 
 output "provides" {
-  value = {}
+  value = {
+    provide_cmr_mesh = "provide-cmr-mesh"
+  }
 }
 
 output "requires" {
   value = {
-    kfp_api = "kfp-api",
-    logging = "logging"
+    kfp_api          = "kfp-api",
+    kfp_api_grpc     = "kfp-api-grpc",
+    logging          = "logging",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh"
   }
 }

--- a/charms/kfp-profile-controller/terraform/outputs.tf
+++ b/charms/kfp-profile-controller/terraform/outputs.tf
@@ -3,12 +3,16 @@ output "app_name" {
 }
 
 output "provides" {
-  value = {}
+  value = {
+    provide_cmr_mesh = "provide-cmr-mesh"
+  }
 }
 
 output "requires" {
   value = {
-    object_storage = "object-storage",
-    logging        = "logging",
+    logging          = "logging",
+    object_storage   = "object-storage",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh"
   }
 }

--- a/charms/kfp-schedwf/terraform/outputs.tf
+++ b/charms/kfp-schedwf/terraform/outputs.tf
@@ -3,11 +3,16 @@ output "app_name" {
 }
 
 output "provides" {
-  value = {}
+  value = {
+    provide_cmr_mesh = "provide-cmr-mesh"
+  }
 }
 
 output "requires" {
   value = {
-    logging = "logging"
+    kfp_api_grpc     = "kfp-api-grpc",
+    logging          = "logging",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh"
   }
 }

--- a/charms/kfp-ui/terraform/outputs.tf
+++ b/charms/kfp-ui/terraform/outputs.tf
@@ -4,16 +4,20 @@ output "app_name" {
 
 output "provides" {
   value = {
-    kfp_ui = "kfp-ui"
+    kfp_ui           = "kfp-ui",
+    provide_cmr_mesh = "provide-cmr-mesh"
   }
 }
 
 output "requires" {
   value = {
-    object_storage  = "object-storage",
-    kfp_api         = "kfp-api",
-    ingress         = "ingress",
-    dashboard_links = "dashboard-links",
-    logging         = "logging"
+    dashboard_links     = "dashboard-links",
+    ingress             = "ingress",
+    istio_ingress_route = "istio-ingress-route",
+    kfp_api             = "kfp-api",
+    logging             = "logging",
+    object_storage      = "object-storage",
+    require_cmr_mesh    = "require-cmr-mesh",
+    service_mesh        = "service-mesh"
   }
 }

--- a/charms/kfp-viz/terraform/outputs.tf
+++ b/charms/kfp-viz/terraform/outputs.tf
@@ -4,12 +4,15 @@ output "app_name" {
 
 output "provides" {
   value = {
-    kfp_viz = "kfp-viz"
+    kfp_viz          = "kfp-viz",
+    provide_cmr_mesh = "provide-cmr-mesh"
   }
 }
 
 output "requires" {
   value = {
-    logging = "logging"
+    logging          = "logging",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh"
   }
 }


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1394

This PR updates the terraform module outputs to include the new ambient mesh relations.
It also includes the addition of the `kfp-api-grpc` relation to tf which was missing from the outputs.