### PR TITLE
[MISC] ci: ensuring to apply release revision

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,8 +109,10 @@ jobs:
 
           if "${{ github.event_name }}" == "pull_request":
               ref = "${{ github.base_ref }}"
+              risk = "pr-${{ github.event.pull_request.number }}"
           else:
               ref = "${{ github.ref_name }}"
+              risk = "edge"
 
           if ref.startswith("track/"):
               track = ref.removeprefix("track/")
@@ -118,8 +120,9 @@ jobs:
               track = "latest"
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"track={track}\n")
-
+              f.write(f"track={track}\n")          
+              f.write(f"channel={track}/{risk}\n")
+          
           print(f"Track: {track}")
 
   build:
@@ -175,8 +178,7 @@ jobs:
       # So the model's name must be kubeflow
       # See: https://github.com/kubeflow/kubeflow/issues/6136
       model: kubeflow
-      channel: ${{ needs.get-charm-paths-track.outputs.track }}/edge
-
+      channel: ${{ needs.get-charm-paths-track.outputs.channel }}
 
   integration:
     name: Integration tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,7 @@ jobs:
     name: Terraform
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     needs:
+      - get-charm-paths-track
       - release
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,7 @@ jobs:
     outputs:
       charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
       track: ${{ steps.determine-track.outputs.track }}
+      channel: ${{ steps.determine-track.outputs.channel }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -119,11 +120,14 @@ jobs:
           else:
               track = "latest"
 
+          channel = f"{track}/{risk}"
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"track={track}\n")          
-              f.write(f"channel={track}/{risk}\n")
+              f.write(f"track={track}\n")
+              f.write(f"channel={channel}\n")
           
           print(f"Track: {track}")
+          print(f"Channel: {channel}")
 
   build:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,7 @@ jobs:
   terraform-checks:
     name: Terraform
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    if: ${{ github.event_name == 'pull_request' }}
     needs:
       - get-charm-paths-track
       - release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
       # So the model's name must be kubeflow
       # See: https://github.com/kubeflow/kubeflow/issues/6136
       model: kubeflow
-      channel: ${{ needs.get-charm-paths-track.outputs.track }}
+      channel: ${{ needs.get-charm-paths-track.outputs.track }}/edge
 
 
   integration:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,12 +108,13 @@ jobs:
         run: |
           import os
 
+          risk = "edge"
+
           if "${{ github.event_name }}" == "pull_request":
               ref = "${{ github.base_ref }}"
-              risk = "pr-${{ github.event.pull_request.number }}"
+              risk = f"{risk}/pr-${{ github.event.pull_request.number }}"
           else:
               ref = "${{ github.ref_name }}"
-              risk = "edge"
 
           if ref.startswith("track/"):
               track = ref.removeprefix("track/")

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,27 +88,6 @@ jobs:
       - run: pipx install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
-  terraform-checks:
-    name: Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
-    strategy:
-      matrix:
-        charm:
-          - kfp-api
-          - kfp-metadata-writer
-          - kfp-persistence
-          - kfp-profile-controller
-          - kfp-schedwf
-          - kfp-ui
-          - kfp-viewer
-          - kfp-viz
-    with:
-      charm-path: ./charms/${{ matrix.charm }}
-      # The namespace is hardcoded in the upstream project
-      # So the model's name must be kubeflow
-      # See: https://github.com/kubeflow/kubeflow/issues/6136
-      model: kubeflow
-
   get-charm-paths-track:
     name: Get charm paths and track
     runs-on: ubuntu-latest
@@ -171,6 +150,32 @@ jobs:
       path-to-charm-directory: ${{ matrix.charm }}
     secrets:
       charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+
+
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    needs:
+      - release
+    strategy:
+      matrix:
+        charm:
+          - kfp-api
+          - kfp-metadata-writer
+          - kfp-persistence
+          - kfp-profile-controller
+          - kfp-schedwf
+          - kfp-ui
+          - kfp-viewer
+          - kfp-viz
+    with:
+      charm-path: ./charms/${{ matrix.charm }}
+      # The namespace is hardcoded in the upstream project
+      # So the model's name must be kubeflow
+      # See: https://github.com/kubeflow/kubeflow/issues/6136
+      model: kubeflow
+      channel: ${{ needs.get-charm-paths-track.outputs.track }}
+
 
   integration:
     name: Integration tests


### PR DESCRIPTION
This ensures that when testing tf apply, we consume from the channel that we have released to. This therefore does not make it necessary to change the default channel in TF modules that has not yet been released to stable

[Reference of the conversation](https://chat.canonical.com/canonical/pl/8w4anegip7r5je9rfpff6wf8zr)