### PR TITLE
chore: use new `istio-gateway-service-account` config for Kubeflow Profiles

### DIFF
--- a/tests/integration/bundles/bundle_ambient.yaml.j2
+++ b/tests/integration/bundles/bundle_ambient.yaml.j2
@@ -31,7 +31,7 @@ applications:
     channel: {{ kubeflow_profiles_channel }}
     scale: 1
     options:
-      istio-gateway-principal: cluster.local/ns/kubeflow/sa/istio-ingress-k8s-istio
+      istio-gateway-service-account: istio-ingress-k8s-istio
       service-mesh-mode: istio-ambient
     trust: {{ kubeflow_profiles_trust }}
   istio-k8s:


### PR DESCRIPTION
After merging https://github.com/canonical/kubeflow-profiles-operator/pull/297, the configuration option for Ambient needs to be updated.