### PR TITLE
feat(kfp-api): allow deployment on any namespace

### DIFF
--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -431,16 +431,6 @@ class KfpApiOperator(CharmBase):
 
         return env_vars
 
-    def _check_model_name(self):
-        if self.model.name != "kubeflow":
-            # Remove when this bug is resolved:
-            # https://github.com/canonical/kfp-operators/issues/389
-            raise ErrorWithStatus(
-                "kfp-api must be deployed to model named `kubeflow` due to"
-                " https://github.com/canonical/kfp-operators/issues/389",
-                BlockedStatus,
-            )
-
     def _check_status(self):
         """Check status of workload and set status accordingly."""
         self._check_leader()
@@ -836,7 +826,6 @@ class KfpApiOperator(CharmBase):
     def _on_event(self, event, force_conflicts: bool = False) -> None:
         # Set up all relations/fetch required data
         try:
-            self._check_model_name()
             self._check_leader()
             self._check_config()
             self._apply_k8s_resources(force_conflicts=force_conflicts)

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -47,9 +47,6 @@ def harness() -> Harness:
     # setup container networking simulation
     harness.set_can_connect(KFP_API_CONTAINER_NAME, True)
 
-    # Set required model name
-    harness.set_model_name("kubeflow")
-
     return harness
 
 
@@ -201,15 +198,6 @@ class TestCharm:
         harness.begin_with_initial_hooks()
         harness.container_pebble_ready(KFP_API_CONTAINER_NAME)
         assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
-
-    @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    @patch("charm.KfpApiOperator.k8s_resource_handler")
-    def test_check_model_name_failure(self, k8s_resource_handler: MagicMock, harness: Harness):
-        """Tests that the charm blocks if model name is not 'kubeflow'."""
-        harness.set_model_name("not-kubeflow")
-        harness.begin_with_initial_hooks()
-        assert isinstance(harness.charm.model.unit.status, BlockedStatus)
-        assert harness.charm.model.unit.status.message.startswith("kfp-api must be deployed to")
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @pytest.mark.parametrize(
@@ -546,7 +534,7 @@ class TestCharm:
     ):
         """Test complete installation with all required relations and verify pebble layer."""
         harness.set_leader(True)
-        model_name = "kubeflow"
+        model_name = "kubeflow-any"
         service_port = "8888"
         harness.set_model_name(model_name)
         harness.update_config({"http-port": service_port})
@@ -676,7 +664,7 @@ class TestCharm:
     ):
         """Test complete installation with all required relations and verify pebble layer."""
         harness.set_leader(True)
-        model_name = "kubeflow"
+        model_name = "kubeflow-any"
         service_port = "8888"
         harness.set_model_name(model_name)
         harness.update_config({"http-port": service_port})
@@ -978,7 +966,7 @@ class TestCharm:
         )
 
         harness.set_leader(True)
-        model_name = "kubeflow"
+        model_name = "kubeflow-any"
         harness.set_model_name(model_name)
         harness.begin()
 
@@ -1095,7 +1083,7 @@ class TestCharm:
             )
 
         harness.set_leader(True)
-        harness.set_model_name("kubeflow")
+        harness.set_model_name("kubeflow-any")
         harness.begin()
 
         manifests = harness.charm.k8s_resource_handler.render_manifests()
@@ -1105,7 +1093,7 @@ class TestCharm:
         )
 
         assert ml_pipeline_service is not None
-        assert ml_pipeline_service.metadata.namespace == "kubeflow"
+        assert ml_pipeline_service.metadata.namespace == "kubeflow-any"
 
         labels = ml_pipeline_service.metadata.labels or {}
         ambient_keys = {
@@ -1117,7 +1105,7 @@ class TestCharm:
 
         if add_mesh_relation:
             assert actual_ambient.get("istio.io/dataplane-mode") == "ambient"
-            assert actual_ambient.get("istio.io/use-waypoint-namespace") == "kubeflow"
+            assert actual_ambient.get("istio.io/use-waypoint-namespace") == "kubeflow-any"
             assert "istio.io/use-waypoint" in actual_ambient
         else:
             assert actual_ambient == {}


### PR DESCRIPTION
Remove `_check_model_name` restriction requiring `kubeflow` model name.

Update unit tests to use parametrized model names.

Ref issue: #866.