### PR TITLE
feat(kfp-viewer): allow deployment on any namespace

### DIFF
--- a/charms/kfp-viewer/src/charm.py
+++ b/charms/kfp-viewer/src/charm.py
@@ -13,7 +13,6 @@ import lightkube
 from charmed_kubeflow_chisme.components.charm_reconciler import CharmReconciler
 from charmed_kubeflow_chisme.components.kubernetes_component import KubernetesComponent
 from charmed_kubeflow_chisme.components.leadership_gate_component import LeadershipGateComponent
-from charmed_kubeflow_chisme.components.model_name_gate_component import ModelNameGateComponent
 from charmed_kubeflow_chisme.kubernetes import create_charm_default_labels
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
@@ -43,13 +42,6 @@ class KfpViewer(CharmBase):
                 name="leadership-gate",
             ),
             depends_on=[],
-        )
-
-        self.model_name_gate = self.charm_reconciler.add(
-            component=ModelNameGateComponent(
-                charm=self, name="model-name-gate", model_name="kubeflow"
-            ),
-            depends_on=[self.leadership_gate],
         )
 
         self.kubernetes_resources = self.charm_reconciler.add(

--- a/charms/kfp-viewer/tests/unit/test_operator.py
+++ b/charms/kfp-viewer/tests/unit/test_operator.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import ops
 import pytest
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import KfpViewer
@@ -30,20 +30,9 @@ def test_not_leader(
     )
 
 
-def test_wrong_model(harness: Harness, mocked_lightkube_client):
-    """Test that charm blocks when it is not deployed to a model named `kubeflow`."""
-    harness.set_leader(True)
-    harness.set_model_name("wrong-name")
-    harness.begin_with_initial_hooks()
-    assert harness.charm.model.unit.status == BlockedStatus(
-        "[model-name-gate] Charm must be deployed to model named kubeflow"
-    )
-
-
 def test_kubernetes_component_created(harness: Harness, mocked_lightkube_client):
     """Test that Kubernetes component is created when we have leadership."""
     harness.set_leader(True)
-    harness.set_model_name("kubeflow")
     harness.begin()
 
     # Mock get_missing_kubernetes_resources to always return an empty list.
@@ -61,7 +50,6 @@ def test_kubernetes_component_created(harness: Harness, mocked_lightkube_client)
 def test_pebble_service_container_running(harness: Harness, mocked_lightkube_client):
     """Test that the pebble service of the charm's kfp-viewer container is running."""
     harness.set_leader(True)
-    harness.set_model_name("kubeflow")
     harness.begin()
     harness.set_can_connect("kfp-viewer", True)
 
@@ -84,7 +72,6 @@ def test_pebble_service_container_running(harness: Harness, mocked_lightkube_cli
 def test_install_before_pebble_service_container(harness: Harness, mocked_lightkube_client):
     """Test that charm waits when install event happens before pebble-service-container is ready."""
     harness.set_leader(True)
-    harness.set_model_name("kubeflow")
     harness.begin()
 
     harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())


### PR DESCRIPTION
Remove `ModelNameGateComponent` restriction requiring `kubeflow` model name.

Remove related unit tests.

Ref issue: #866.