### PR TITLE
feat(kfp-profile-controller): allow deployment on any namespace

### DIFF
--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -22,9 +22,4 @@ options:
 
       Note that manual deletion of old ConfigMaps is required after updating this, refer to:
       https://github.com/kubeflow/manifests/blob/v1.11.0/applications/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml#L40-L42
-  kfp-api-principal:
-    type: string
-    default: "cluster.local/ns/kubeflow/sa/kfp-api"
-    description: >
-      The principal for the KFP API service account.
-      This is used in the AuthorizationPolicy that gets created in the sync.py script.
+

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -189,7 +189,7 @@ def server_factory(visualization_server_image,
             providers_yaml = (
                 "s3:\n"
                 "  default:\n"
-                f"    endpoint: {minio_host}.{minio_namespace}:9000\n"
+                f"    endpoint: {minio_host}.{minio_namespace}:{minio_port}\n"
                 "    disableSSL: true\n"
                 "    region: us-east-1\n"
                 "    forcePathStyle: true\n"

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -217,7 +217,7 @@ class KfpProfileControllerOperator(CharmBase):
                     VISUALIZATION_SERVER_TAG=self.images["visualization_server__version"],
                     FRONTEND_IMAGE=self.images["frontend__image"],
                     FRONTEND_TAG=self.images["frontend__version"],
-                    KFP_API_PRINCIPAL=str(self.model.config["kfp-api-principal"]),
+                    KFP_API_PRINCIPAL=f"cluster.local/ns/{self.model.name}/sa/kfp-api",
                     AMBIENT_ENABLED=self.service_mesh_component.component.ambient_mesh_enabled,
                     HOOKS_PATH=HOOKS_PATH,
                 ),

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -59,7 +59,6 @@ KFP_IMAGES_VERSION = "2.16.0"  # Remember to change this version also in default
 # This service name must be the Service from the mlmd-operator
 # FIXME: leaving it hardcoded now, but we should share this
 # host and port through relation data
-METADATA_GRPC_SERVICE_HOST = "metadata-grpc-service.kubeflow"
 METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
@@ -116,6 +115,7 @@ class KfpProfileControllerOperator(CharmBase):
         self.default_pipeline_root = self.model.config["default_pipeline_root"]
 
         self._container_name = next(iter(self.meta.containers))
+        self.metadata_grpc_service_host = f"metadata-grpc-service.{self.model.name}"
 
         # expose controller's port
         http_port = ServicePort(K8S_SVC_CONTROLLER_PORT, name="http", targetPort=CONTROLLER_PORT)
@@ -211,7 +211,7 @@ class KfpProfileControllerOperator(CharmBase):
                     KFP_DEFAULT_PIPELINE_ROOT=self.default_pipeline_root,
                     DISABLE_ISTIO_SIDECAR=DISABLE_ISTIO_SIDECAR,
                     CONTROLLER_PORT=CONTROLLER_PORT,
-                    METADATA_GRPC_SERVICE_HOST=METADATA_GRPC_SERVICE_HOST,
+                    METADATA_GRPC_SERVICE_HOST=self.metadata_grpc_service_host,
                     METADATA_GRPC_SERVICE_PORT=METADATA_GRPC_SERVICE_PORT,
                     VISUALIZATION_SERVER_IMAGE=self.images["visualization_server__image"],
                     VISUALIZATION_SERVER_TAG=self.images["visualization_server__version"],

--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -204,21 +204,6 @@ async def test_insecure_authorization_policy_is_missing(
     assert excinfo.value.response.status_code == 404
 
 
-# Targeted for ambient integration
-@pytest.mark.abort_on_fail
-async def test_kfp_api_principal_changed(
-    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
-):
-    """Test that the principal in the AuthorizationPolicy changes on config-change."""
-    new_principal = "test"
-    await ops_test.model.applications[CHARM_NAME].set_config({"kfp-api-principal": new_principal})
-    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=600)
-
-    # ensure the AuthorizationPolicy in Profile is updated
-    policy = get_authorization_policy(AMBIENT_AP_NAME, profile, lightkube_client)
-    assert policy["spec"]["rules"][0]["from"][0]["source"]["principals"][0] == new_principal
-
-
 @tenacity.retry(
     wait=wait_exponential(multiplier=1, min=1, max=5),
     stop=stop_after_delay(60 * 2),

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -22,7 +22,6 @@ from charm import (
 
 CONFIG_NAME_FOR_CUSTOM_IMAGES = "custom_images"
 CONFIG_NAME_FOR_DEFAULT_PIPELINE_ROOT = "default_pipeline_root"
-CONFIG_NAME_FOR_KFP_API_PRINCIPAL = "kfp-api-principal"
 
 # Load the custom images from the JSON
 CUSTOM_IMAGES_PATH = Path("./src/default-custom-images.json")
@@ -208,13 +207,12 @@ def test_kubernetes_created_method(
 
 
 @pytest.mark.parametrize(
-    "do_update_config_for_default_pipeline_root,mesh_relation,kfp_api_principal",
-    [(False, False, "principal1"), (True, True, "principal2")],
+    "do_update_config_for_default_pipeline_root,mesh_relation",
+    [(False, False), (True, True)],
 )
 def test_pebble_services_running(
     do_update_config_for_default_pipeline_root: bool,
     mesh_relation: bool,
-    kfp_api_principal: str,
     harness: Harness,
     mocked_lightkube_client,
     mocked_kubernetes_service_patch,
@@ -235,10 +233,6 @@ def test_pebble_services_running(
         relation_id = harness.add_relation("service-mesh", "istio-beacon-k8s")
         harness.add_relation_unit(relation_id, "istio-beacon-k8s/0")
         expected_environment["AMBIENT_ENABLED"] = mesh_relation
-
-    # principal should have changed
-    harness.update_config({CONFIG_NAME_FOR_KFP_API_PRINCIPAL: kfp_api_principal})
-    expected_environment["KFP_API_PRINCIPAL"] = kfp_api_principal
 
     # Mock:
     # * leadership_gate to have get_status=>Active

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import json
-from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +16,6 @@ from charm import (
     CONTROLLER_PORT,
     DISABLE_ISTIO_SIDECAR,
     KFP_IMAGES_VERSION,
-    METADATA_GRPC_SERVICE_HOST,
     METADATA_GRPC_SERVICE_PORT,
     KfpProfileControllerOperator,
 )
@@ -46,27 +44,29 @@ MOCK_OBJECT_STORAGE_DATA = {
     "secure": True,
 }
 
-EXPECTED_ENVIRONMENT_BY_DEFAULT = {
-    "CONTROLLER_PORT": CONTROLLER_PORT,
-    "DISABLE_ISTIO_SIDECAR": DISABLE_ISTIO_SIDECAR,
-    "KFP_DEFAULT_PIPELINE_ROOT": KFP_DEFAULT_PIPELINE_ROOT,
-    "KFP_VERSION": KFP_IMAGES_VERSION,
-    "METADATA_GRPC_SERVICE_HOST": METADATA_GRPC_SERVICE_HOST,
-    "METADATA_GRPC_SERVICE_PORT": METADATA_GRPC_SERVICE_PORT,
-    "MINIO_ACCESS_KEY": MOCK_OBJECT_STORAGE_DATA["access-key"],
-    "MINIO_HOST": MOCK_OBJECT_STORAGE_DATA["service"],
-    "MINIO_NAMESPACE": MOCK_OBJECT_STORAGE_DATA["namespace"],
-    "MINIO_PORT": MOCK_OBJECT_STORAGE_DATA["port"],
-    "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
-    # Using custom image and tag from the JSON file
-    "FRONTEND_IMAGE": custom_images["frontend"].split(":")[0],
-    "FRONTEND_TAG": custom_images["frontend"].split(":")[1],
-    "VISUALIZATION_SERVER_IMAGE": custom_images["visualization_server"].split(":")[0],
-    "VISUALIZATION_SERVER_TAG": custom_images["visualization_server"].split(":")[1],
-    # ambient
-    "AMBIENT_ENABLED": False,
-    "KFP_API_PRINCIPAL": "cluster.local/ns/kubeflow/sa/kfp-api",
-}
+
+def generate_expected_environment(model_name: str) -> dict:
+    return {
+        "CONTROLLER_PORT": CONTROLLER_PORT,
+        "DISABLE_ISTIO_SIDECAR": DISABLE_ISTIO_SIDECAR,
+        "KFP_DEFAULT_PIPELINE_ROOT": KFP_DEFAULT_PIPELINE_ROOT,
+        "KFP_VERSION": KFP_IMAGES_VERSION,
+        "METADATA_GRPC_SERVICE_HOST": f"metadata-grpc-service.{model_name}",
+        "METADATA_GRPC_SERVICE_PORT": METADATA_GRPC_SERVICE_PORT,
+        "MINIO_ACCESS_KEY": MOCK_OBJECT_STORAGE_DATA["access-key"],
+        "MINIO_HOST": MOCK_OBJECT_STORAGE_DATA["service"],
+        "MINIO_NAMESPACE": MOCK_OBJECT_STORAGE_DATA["namespace"],
+        "MINIO_PORT": MOCK_OBJECT_STORAGE_DATA["port"],
+        "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
+        # Using custom image and tag from the JSON file
+        "FRONTEND_IMAGE": custom_images["frontend"].split(":")[0],
+        "FRONTEND_TAG": custom_images["frontend"].split(":")[1],
+        "VISUALIZATION_SERVER_IMAGE": custom_images["visualization_server"].split(":")[0],
+        "VISUALIZATION_SERVER_TAG": custom_images["visualization_server"].split(":")[1],
+        # ambient
+        "AMBIENT_ENABLED": False,
+        "KFP_API_PRINCIPAL": f"cluster.local/ns/{model_name}/sa/kfp-api",
+    }
 
 
 @pytest.fixture
@@ -221,7 +221,7 @@ def test_pebble_services_running(
 ):
     """Test that if the Kubernetes Component is Active, the pebble services successfully start."""
     # Arrange
-    expected_environment = deepcopy(EXPECTED_ENVIRONMENT_BY_DEFAULT)
+    expected_environment = generate_expected_environment(harness.model.name)
     if do_update_config_for_default_pipeline_root:
         updated_default_pipeline_root = "s3://whatever-s3-bucket/whatever/s3/path"
         harness.update_config(


### PR DESCRIPTION
This PR adds the capability to deploy KFP profile controller on any namespace.

## Metadata gRPC service host
This value is now dynamically created from the charm model.
Unit test is updated accordingly.

## KFP API principal
The configuration option `kfp-api-principal` is removed and its value is now dynamically created from the charm model.
Related unit test is removed.

Ref issue: #866.

This PR closes #389.