### PR TITLE
feat(ci): allow deployment on any namespace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Run test
         run: |
-          tox -e bundle-${{ matrix.test-type }} -- --model testing --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
+          tox -e bundle-${{ matrix.test-type }} -- --model=testing --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
 
       - name: Get juju status
         run: juju status --relations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,10 +180,6 @@ jobs:
           - kfp-viz
     with:
       charm-path: ./charms/${{ matrix.charm }}
-      # The namespace is hardcoded in the upstream project
-      # So the model's name must be kubeflow
-      # See: https://github.com/kubeflow/kubeflow/issues/6136
-      model: kubeflow
       channel: ${{ needs.get-charm-paths-track.outputs.channel }}
 
   integration:
@@ -251,13 +247,10 @@ jobs:
 
       - name: Integration tests
         run: |
-          # Requires the model to be called kubeflow due to
-          # https://github.com/canonical/kfp-operators/issues/389
-          juju add-model kubeflow
           # Pass the path where the charm artefact is downloaded to the tox command
           # FIXME: Right now the complete path is half hardcoded to <charm name>_ubuntu@24.04-amd64.charm
           # We need to find a better way to dynamically get this value
-          tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
+          tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model testing --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
@@ -317,9 +310,7 @@ jobs:
 
       - name: Run test
         run: |
-          # Requires the model to be called kubeflow due to kfp-viewer
-          juju add-model kubeflow
-          tox -e bundle-${{ matrix.test-type }} -- --model=kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
+          tox -e bundle-${{ matrix.test-type }} -- --model testing --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
 
       - name: Get all
         run: kubectl get all -A

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -110,10 +110,10 @@ def juju(request: pytest.FixtureRequest):
 
 
 @pytest.fixture(scope="session")
-def forward_kfp_ui():
+def forward_kfp_ui(juju: jubilant.Juju):
     """Port forward the kfp-ui service."""
     kfp_ui_process = subprocess.Popen(
-        ["kubectl", "port-forward", "-n", "kubeflow", "svc/kfp-ui", "8080:3000"]
+        ["kubectl", "port-forward", "-n", juju.model, "svc/kfp-ui", "8080:3000"]
     )
 
     # FIXME: find a better way to do this
@@ -154,10 +154,10 @@ def apply_profile(lightkube_client):
 
 
 @pytest.fixture(scope="session")
-def kfp_client(apply_profile, forward_kfp_ui) -> kfp.Client:
+def kfp_client(apply_profile, forward_kfp_ui, juju: jubilant.Juju) -> kfp.Client:
     """Returns a KFP Client that can talk to the KFP API Server."""
     # Instantiate the KFP Client
-    client = kfp.Client(host=KUBEFLOW_LOCAL_HOST, namespace=KUBEFLOW_PROFILE_NAMESPACE)
+    client = kfp.Client(host=KUBEFLOW_LOCAL_HOST, namespace=juju.model)
     client.runs.api_client.default_headers.update({"kubeflow-userid": KUBEFLOW_USER_NAME})
     return client
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,7 +109,7 @@ def juju(request: pytest.FixtureRequest):
                 print_debug_log(juju_instance)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def forward_kfp_ui(juju: jubilant.Juju):
     """Port forward the kfp-ui service."""
     kfp_ui_process = subprocess.Popen(
@@ -125,14 +125,14 @@ def forward_kfp_ui(juju: jubilant.Juju):
     kfp_ui_process.terminate()
 
 
-@pytest.fixture(scope="session")
-def apply_profile(lightkube_client):
+@pytest.fixture(scope="module")
+def apply_profile(lightkube_client, juju: jubilant.Juju):
     """Apply a Profile simulating a user."""
     # Create a Viewer namespaced resource
     create_global_resource(group="kubeflow.org", version="v1", kind="Profile", plural="profiles")
 
     # Apply Profile first
-    apply_manifests(lightkube_client, PROFILE_FILE_PATH)
+    apply_manifests(lightkube_client, PROFILE_FILE_PATH, context={"namespace": juju.model})
 
     # Ensure "kfp-launcher" configmap has been created on the profile namespace
     wait_for_configmap(lightkube_client, KFP_LAUNCHER_CONFIGMAP_NAME, KUBEFLOW_PROFILE_NAMESPACE)
@@ -153,7 +153,7 @@ def apply_profile(lightkube_client):
             raise api_error
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def kfp_client(apply_profile, forward_kfp_ui, juju: jubilant.Juju) -> kfp.Client:
     """Returns a KFP Client that can talk to the KFP API Server."""
     # Instantiate the KFP Client

--- a/tests/integration/helpers/k8s_resources.py
+++ b/tests/integration/helpers/k8s_resources.py
@@ -3,24 +3,33 @@
 # See LICENSE file for licensing details.
 """Helpers for handling K8s resources."""
 from pathlib import Path
+from typing import Optional
 
+import jinja2
 import lightkube
 from lightkube import codecs
 
 
-def apply_manifests(lightkube_client: lightkube.Client, yaml_file_path: str):
+def apply_manifests(
+    lightkube_client: lightkube.Client,
+    yaml_template_path: str,
+    context: Optional[dict] = None,
+):
     """Apply resources using manifest files and returns the applied object.
 
     Args:
         lightkube_client (lightkube.Client): an instance of lightkube.Client to
             use for applying resources.
-        yaml_file_path (str): the resource yaml file.
+        yaml_template_path (str): path to a YAML Jinja2 template file.
+        context (Optional[dict]): a dictionary of variables to render the
+            yaml file as a Jinja2 template. If None, the file is used as-is.
 
     Returns:
         A namespaced or global lightkube resource (obj).
     """
-    read_yaml = Path(yaml_file_path).read_text()
-    yaml_loaded = codecs.load_all_yaml(read_yaml)
+    read_yaml = Path(yaml_template_path).read_text()
+    compiled_yaml = jinja2.Template(read_yaml).render(**context)
+    yaml_loaded = codecs.load_all_yaml(compiled_yaml)
     for obj in yaml_loaded:
         try:
             lightkube_client.apply(

--- a/tests/integration/kfp_globals.py
+++ b/tests/integration/kfp_globals.py
@@ -27,7 +27,7 @@ SAMPLE_PIPELINE = f"{SAMPLE_PIPELINES_PATH}/pipeline_container_no_input.yaml"
 SAMPLE_PIPELINE_NAME = "sample-pipeline"
 
 # Variables for creating a viewer
-SAMPLE_VIEWER = f"{basedir}/tests/integration/viewer/mnist.yaml"
+SAMPLE_VIEWER = f"{basedir}/tests/integration/viewer/mnist.yaml.j2"
 KUBEFLOW_PROFILE_NAMESPACE = "kubeflow-user-example-com"
 
 # Variables for configuring the KFP Client

--- a/tests/integration/test_kfp_functional.py
+++ b/tests/integration/test_kfp_functional.py
@@ -33,6 +33,7 @@ from kfp_globals import (
     SAMPLE_PIPELINE_NAME,
     SAMPLE_VIEWER,
 )
+from lightkube import Client
 from lightkube.generic_resource import create_namespaced_resource
 
 charms_dependencies_list = [
@@ -86,12 +87,8 @@ def create_and_clean_experiment_v2(kfp_client: kfp.Client):
 
 @pytest.mark.deploy
 @pytest.mark.abort_on_fail
-def test_deploy(juju: jubilant.Juju, request, lightkube_client):
+def test_deploy(juju: jubilant.Juju, request: pytest.FixtureRequest, lightkube_client: Client):
     """Deploy kfp-operators charms."""
-
-    # Immediately raise an error if the model name is not kubeflow
-    if juju.model != "kubeflow":
-        raise ValueError("kfp must be deployed to namespace kubeflow")
 
     # Get/load template bundle from command line args
     bundlefile_path = Path(request.config.getoption("bundle"))
@@ -120,7 +117,7 @@ def test_deploy(juju: jubilant.Juju, request, lightkube_client):
 
 
 # ---- KFP API Server focused test cases
-def test_upload_pipeline(kfp_client):
+def test_upload_pipeline(kfp_client: kfp.Client):
     """Upload a pipeline from a YAML file and assert its presence."""
     # Upload a pipeline and get the server response
     pipeline_name = "test-pipeline"
@@ -146,7 +143,7 @@ def test_upload_pipeline(kfp_client):
     kfp_client.delete_pipeline(pipeline_upload_response.pipeline_id)
 
 
-def test_create_and_monitor_run(kfp_client, create_and_clean_experiment_v2):
+def test_create_and_monitor_run(kfp_client: kfp.Client, create_and_clean_experiment_v2):
     """Create a run and monitor it to completion."""
     # Create a run, save response in variable for easy manipulation
     # Create an experiment for this run
@@ -171,7 +168,7 @@ def test_create_and_monitor_run(kfp_client, create_and_clean_experiment_v2):
 
 # ---- ScheduledWorfklows and Argo focused test case
 def test_create_and_monitor_recurring_run(
-    kfp_client, upload_and_clean_pipeline_v2, create_and_clean_experiment_v2
+    kfp_client: kfp.Client, upload_and_clean_pipeline_v2, create_and_clean_experiment_v2
 ):
     """Create a recurring run and monitor it to completion."""
 
@@ -231,7 +228,7 @@ def test_create_and_monitor_recurring_run(
 
 
 # ---- KFP Viewer and Visualization focused test cases
-def test_apply_sample_viewer(lightkube_client):
+def test_apply_sample_viewer(lightkube_client: Client):
     """Test a Viewer can be applied and its presence is verified."""
     # Create a Viewer namespaced resource
     viewer_class_resource = create_namespaced_resource(

--- a/tests/integration/test_kfp_functional.py
+++ b/tests/integration/test_kfp_functional.py
@@ -228,7 +228,7 @@ def test_create_and_monitor_recurring_run(
 
 
 # ---- KFP Viewer and Visualization focused test cases
-def test_apply_sample_viewer(lightkube_client: Client):
+def test_apply_sample_viewer(juju: jubilant.Juju, lightkube_client: Client):
     """Test a Viewer can be applied and its presence is verified."""
     # Create a Viewer namespaced resource
     viewer_class_resource = create_namespaced_resource(
@@ -236,7 +236,9 @@ def test_apply_sample_viewer(lightkube_client: Client):
     )
 
     # Apply viewer
-    viewer_object = apply_manifests(lightkube_client, yaml_file_path=SAMPLE_VIEWER)
+    viewer_object = apply_manifests(
+        lightkube_client, yaml_template_path=SAMPLE_VIEWER, context={"namespace": juju.model}
+    )
 
     viewer = lightkube_client.get(
         res=viewer_class_resource,

--- a/tests/integration/test_kfp_functional_ambient.py
+++ b/tests/integration/test_kfp_functional_ambient.py
@@ -34,6 +34,7 @@ from kfp_globals import (
     SAMPLE_PIPELINE_NAME,
     SAMPLE_VIEWER,
 )
+from lightkube import Client
 from lightkube.generic_resource import create_namespaced_resource
 
 charms_dependencies_list = [
@@ -88,12 +89,8 @@ def create_and_clean_experiment_v2(kfp_client: kfp.Client):
 
 @pytest.mark.deploy
 @pytest.mark.abort_on_fail
-def test_deploy(juju: jubilant.Juju, request, lightkube_client):
+def test_deploy(juju: jubilant.Juju, request: pytest.FixtureRequest, lightkube_client: Client):
     """Deploy kfp-operators charms."""
-
-    # Immediately raise an error if the model name is not kubeflow
-    if juju.model != "kubeflow":
-        raise ValueError("kfp must be deployed to namespace kubeflow")
 
     # Get/load template bundle from command line args
     bundlefile_path = Path(request.config.getoption("bundle"))
@@ -122,7 +119,7 @@ def test_deploy(juju: jubilant.Juju, request, lightkube_client):
 
 
 # ---- KFP API Server focused test cases
-def test_upload_pipeline(kfp_client):
+def test_upload_pipeline(kfp_client: kfp.Client):
     """Upload a pipeline from a YAML file and assert its presence."""
     # Upload a pipeline and get the server response
     pipeline_name = "test-pipeline"
@@ -148,7 +145,7 @@ def test_upload_pipeline(kfp_client):
     kfp_client.delete_pipeline(pipeline_upload_response.pipeline_id)
 
 
-def test_create_and_monitor_run(kfp_client, create_and_clean_experiment_v2):
+def test_create_and_monitor_run(kfp_client: kfp.Client, create_and_clean_experiment_v2):
     """Create a run and monitor it to completion."""
     # Create a run, save response in variable for easy manipulation
     # Create an experiment for this run
@@ -173,7 +170,7 @@ def test_create_and_monitor_run(kfp_client, create_and_clean_experiment_v2):
 
 # ---- ScheduledWorfklows and Argo focused test case
 def test_create_and_monitor_recurring_run(
-    kfp_client, upload_and_clean_pipeline_v2, create_and_clean_experiment_v2
+    kfp_client: kfp.Client, upload_and_clean_pipeline_v2, create_and_clean_experiment_v2
 ):
     """Create a recurring run and monitor it to completion."""
 
@@ -233,7 +230,7 @@ def test_create_and_monitor_recurring_run(
 
 
 # ---- KFP Viewer and Visualization focused test cases
-def test_apply_sample_viewer(lightkube_client):
+def test_apply_sample_viewer(lightkube_client: Client):
     """Test a Viewer can be applied and its presence is verified."""
     # Create a Viewer namespaced resource
     viewer_class_resource = create_namespaced_resource(

--- a/tests/integration/test_kfp_functional_ambient.py
+++ b/tests/integration/test_kfp_functional_ambient.py
@@ -230,7 +230,7 @@ def test_create_and_monitor_recurring_run(
 
 
 # ---- KFP Viewer and Visualization focused test cases
-def test_apply_sample_viewer(lightkube_client: Client):
+def test_apply_sample_viewer(juju: jubilant.Juju, lightkube_client: Client):
     """Test a Viewer can be applied and its presence is verified."""
     # Create a Viewer namespaced resource
     viewer_class_resource = create_namespaced_resource(
@@ -238,7 +238,9 @@ def test_apply_sample_viewer(lightkube_client: Client):
     )
 
     # Apply viewer
-    viewer_object = apply_manifests(lightkube_client, yaml_file_path=SAMPLE_VIEWER)
+    viewer_object = apply_manifests(
+        lightkube_client, yaml_template_path=SAMPLE_VIEWER, context={"namespace": juju.model}
+    )
 
     viewer = lightkube_client.get(
         res=viewer_class_resource,

--- a/tests/integration/viewer/mnist.yaml.j2
+++ b/tests/integration/viewer/mnist.yaml.j2
@@ -19,7 +19,7 @@ apiVersion: "kubeflow.org/v1beta1"
 kind: Viewer
 metadata:
   name: viewer-mnist
-  namespace: kubeflow
+  namespace: {{ namespace }}
 spec:
   type: tensorboard
   tensorboardSpec:


### PR DESCRIPTION
This PR removes hardcoded `kubeflow` model name from CI and integration tests. Now the CI uses '`testing` model and parametrize namespace references.

Ref issue: #866.