### PR TITLE
chore: bump actions to newer versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,6 +352,18 @@ jobs:
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
         if: failure()
 
+      - name: Get operator and workload logs
+        run: |
+          CHARMS=(kfp-api kfp-metadata-writer kfp-persistence kfp-profile-controller kfp-schedwf kfp-ui kfp-viewer kfp-viz)
+          for CHARM in ${CHARMS[@]}; do
+            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}')
+            CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
+            for CONTAINER in ${CONTAINERS[@]}; do
+              kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
+              done
+          done
+        if: failure()
+
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
         if: failure()
@@ -360,5 +372,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: /tmp/juju*.log
+          path: |
+            /tmp/juju*.log
+            /tmp/kubectl-logs*.log
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,18 +242,18 @@ jobs:
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee tmp/juju-status-${{ matrix.charm }}.txt
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.txt
         if: failure()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee tmp/juju-debug-log-${{ matrix.charm }}.txt
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.txt
         if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: tmp
+          path: /tmp/juju*
         if: failure()
 
   test-bundle:
@@ -317,16 +317,16 @@ jobs:
         if: failure()
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee tmp/juju-status.txt
-        if: failure()
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status.txt
+        if: always()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee tmp/juju-debug-log.txt
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.txt
         if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: tmp
-        if: failure()
+          path: /tmp/juju*
+        if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,18 +242,18 @@ jobs:
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.txt
+        run: juju status -m kubeflow --relations | tee tmp/juju-status-${{ matrix.charm }}.txt
         if: failure()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.txt
+        run: juju debug-log -m kubeflow --replay --no-tail | tee tmp/juju-debug-log-${{ matrix.charm }}.txt
         if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: /tmp
+          path: tmp
         if: failure()
 
   test-bundle:
@@ -317,16 +317,16 @@ jobs:
         if: failure()
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status.txt
+        run: juju status -m kubeflow --relations | tee tmp/juju-status.txt
         if: failure()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.txt
+        run: juju debug-log -m kubeflow --replay --no-tail | tee tmp/juju-debug-log.txt
         if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: /tmp
+          path: tmp
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,7 +357,7 @@ jobs:
         run: |
           CHARMS=(kfp-api kfp-metadata-writer kfp-persistence kfp-profile-controller kfp-schedwf kfp-ui kfp-viewer kfp-viz)
           for CHARM in ${CHARMS[@]}; do
-            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}')
+            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}') || continue
             CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
             for CONTAINER in ${CONTAINERS[@]}; do
               kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,19 +242,19 @@ jobs:
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.txt
-        if: failure()
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.log
+        if: failure() || cancelled()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.txt
-        if: failure()
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.log
+        if: failure() || cancelled()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: /tmp/juju*
-        if: failure()
+          path: /tmp/juju*.log
+        if: failure() || cancelled()
 
   test-bundle:
     name: Test the bundle
@@ -317,16 +317,16 @@ jobs:
         if: failure()
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status.txt
-        if: always()
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
+        if: failure() || cancelled()
 
       - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.txt
-        if: failure()
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
+        if: failure() || cancelled()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
-          path: /tmp/juju*
-        if: always()
+          path: /tmp/juju*.log
+        if: failure() || cancelled()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - run: pipx install tox
-      - run: tox -e lint
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e lint
 
   lint:
     name: Lint
@@ -46,9 +50,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-lint
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-lint
 
   unit:
     name: Unit tests
@@ -66,9 +74,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-unit
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-unit
 
   get-charm-paths-track:
     name: Get charm paths and track
@@ -78,12 +90,15 @@ jobs:
       track: ${{ steps.determine-track.outputs.track }}
       channel: ${{ steps.determine-track.outputs.channel }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Get paths for all charms in this repo
         id: get-charm-paths
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
+
       - name: Determine track
         id: determine-track
         shell: python
@@ -204,7 +219,10 @@ jobs:
       - name: Maximise GH runner space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -218,7 +236,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -290,7 +308,10 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -312,7 +333,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.log
-        if: failure()
+        if: always()
 
       - name: Get operator and workload logs
         run: |
@@ -351,7 +351,7 @@ jobs:
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
-        if: failure()
+        if: always()
 
       - name: Get operator and workload logs
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,11 +347,11 @@ jobs:
       - name: Get all
         run: |
           kubectl get all -A | tee /tmp/kubectl-logs-all.log
-        if: always()
+        if: failure()
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
-        if: always()
+        if: failure()
 
       - name: Get operator and workload logs
         run: |
@@ -363,11 +363,11 @@ jobs:
               kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
               done
           done
-        if: always()
+        if: failure()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
-        if: always()
+        if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
@@ -376,4 +376,4 @@ jobs:
           path: |
             /tmp/juju*.log
             /tmp/kubectl-logs*.log
-        if: always()
+        if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,11 +347,11 @@ jobs:
       - name: Get all
         run: |
           kubectl get all -A | tee /tmp/kubectl-logs-all.log
-        if: failure() || cancelled()
+        if: always()
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
-        if: failure() || cancelled()
+        if: always()
 
       - name: Get operator and workload logs
         run: |
@@ -363,11 +363,11 @@ jobs:
               kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
               done
           done
-        if: failure() || cancelled()
+        if: always()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
-        if: failure() || cancelled()
+        if: always()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
@@ -376,4 +376,4 @@ jobs:
           path: |
             /tmp/juju*.log
             /tmp/kubectl-logs*.log
-        if: failure() || cancelled()
+        if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,18 +243,29 @@ jobs:
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.log
-        if: failure() || cancelled()
+        if: failure()
+
+      - name: Get operator and workload logs
+        run: |
+          POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${{ matrix.charm }} -o jsonpath='{.items[0].metadata.name}')
+          CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
+          for CONTAINER in ${CONTAINERS[@]}; do
+            kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${{ matrix.charm }}-${CONTAINER}.log
+          done
+        if: failure()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.log
-        if: failure() || cancelled()
+        if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: test-run-artifacts
-          path: /tmp/juju*.log
-        if: failure() || cancelled()
+          name: test-run-artifacts-${{ matrix.charm }}
+          path: |
+            /tmp/juju*.log
+            /tmp/kubectl-logs*.log
+        if: failure()
 
   test-bundle:
     name: Test the bundle
@@ -318,15 +329,15 @@ jobs:
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
-        if: failure() || cancelled()
+        if: failure()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
-        if: failure() || cancelled()
+        if: failure()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
         with:
           name: test-run-artifacts
           path: /tmp/juju*.log
-        if: failure() || cancelled()
+        if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,10 +241,19 @@ jobs:
           # We need to find a better way to dynamically get this value
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
-      - name: Collect charm debug artifacts
-        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+      - name: Get juju status
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.txt
+        if: failure()
+
+      - name: Get juju debug-log
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.txt
+        if: failure()
+
+      - name: Upload debug artifacts
+        uses: actions/upload-artifact@v7
         with:
-          artifact-prefix: ${{ matrix.charm }}
+          name: test-run-artifacts
+          path: /tmp
         if: failure()
 
   test-bundle:
@@ -308,11 +317,16 @@ jobs:
         if: failure()
 
       - name: Get juju status
-        run: juju status
+        run: juju status -m kubeflow --relations | tee /tmp/juju-status.txt
         if: failure()
 
-      # Collect debug artefacts only on failure || cancelled as the CI for this repository
-      # in particular struggles with storage limitations.
-      - name: Collect charm debug artifacts
-        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: failure() || cancelled()
+      - name: Get juju debug-log
+        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.txt
+        if: failure()
+
+      - name: Upload debug artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-run-artifacts
+          path: /tmp
+        if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,12 +345,13 @@ jobs:
           tox -e bundle-${{ matrix.test-type }} -- --model=kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
 
       - name: Get all
-        run: kubectl get all -A
-        if: failure()
+        run: |
+          kubectl get all -A | tee /tmp/kubectl-logs-all.log
+        if: failure() || cancelled()
 
       - name: Get juju status
         run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
-        if: failure()
+        if: failure() || cancelled()
 
       - name: Get operator and workload logs
         run: |
@@ -362,11 +363,11 @@ jobs:
               kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
               done
           done
-        if: failure()
+        if: failure() || cancelled()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
-        if: failure()
+        if: failure() || cancelled()
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v7
@@ -375,4 +376,4 @@ jobs:
           path: |
             /tmp/juju*.log
             /tmp/kubectl-logs*.log
-        if: failure()
+        if: failure() || cancelled()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,12 +265,15 @@ jobs:
 
       - name: Get operator and workload logs
         run: |
-          POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${{ matrix.charm }} -o jsonpath='{.items[0].metadata.name}')
-          CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
-          for CONTAINER in ${CONTAINERS[@]}; do
-            kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${{ matrix.charm }}-${CONTAINER}.log
+          CHARMS=($(juju status -m kubeflow --format json | jq -r '.applications | keys | join (" ")'))
+          for CHARM in ${CHARMS[@]}; do
+            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}') || continue
+            CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
+            for CONTAINER in ${CONTAINERS[@]}; do
+              kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
+              done
           done
-        if: failure()
+        if: always()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.log
@@ -355,7 +358,7 @@ jobs:
 
       - name: Get operator and workload logs
         run: |
-          CHARMS=(kfp-api kfp-metadata-writer kfp-persistence kfp-profile-controller kfp-schedwf kfp-ui kfp-viewer kfp-viz)
+          CHARMS=($(juju status -m kubeflow --format json | jq -r '.applications | keys | join (" ")'))
           for CHARM in ${CHARMS[@]}; do
             POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}') || continue
             CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
@@ -363,7 +366,7 @@ jobs:
               kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
               done
           done
-        if: failure()
+        if: always()
 
       - name: Get juju debug-log
         run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
@@ -376,4 +379,4 @@ jobs:
           path: |
             /tmp/juju*.log
             /tmp/kubectl-logs*.log
-        if: failure()
+        if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,33 +260,15 @@ jobs:
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status-${{ matrix.charm }}.log
+        run: juju status --relations
         if: always()
 
-      - name: Get operator and workload logs
-        run: |
-          CHARMS=($(juju status -m kubeflow --format json | jq -r '.applications | keys | join (" ")'))
-          for CHARM in ${CHARMS[@]}; do
-            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}') || continue
-            CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
-            for CONTAINER in ${CONTAINERS[@]}; do
-              kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
-              done
-          done
-        if: always()
-
-      - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log-${{ matrix.charm }}.log
-        if: failure()
-
-      - name: Upload debug artifacts
-        uses: actions/upload-artifact@v7
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@chore/update-dump-charm-debug-artifacts
         with:
-          name: test-run-artifacts-${{ matrix.charm }}
-          path: |
-            /tmp/juju*.log
-            /tmp/kubectl-logs*.log
-        if: failure()
+          artifact-prefix: ${{ matrix.charm }}
+        if: always()
+
 
   test-bundle:
     name: Test the bundle
@@ -347,36 +329,10 @@ jobs:
           juju add-model kubeflow
           tox -e bundle-${{ matrix.test-type }} -- --model=kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
 
-      - name: Get all
-        run: |
-          kubectl get all -A | tee /tmp/kubectl-logs-all.log
-        if: failure()
-
       - name: Get juju status
-        run: juju status -m kubeflow --relations | tee /tmp/juju-status.log
+        run: juju status --relations
         if: always()
 
-      - name: Get operator and workload logs
-        run: |
-          CHARMS=($(juju status -m kubeflow --format json | jq -r '.applications | keys | join (" ")'))
-          for CHARM in ${CHARMS[@]}; do
-            POD=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=${CHARM} -o jsonpath='{.items[0].metadata.name}') || continue
-            CONTAINERS=($(kubectl get pod -n kubeflow ${POD} -o jsonpath='{.spec.containers[*].name}'))
-            for CONTAINER in ${CONTAINERS[@]}; do
-              kubectl logs -n kubeflow ${POD} -c ${CONTAINER} | tee /tmp/kubectl-logs-${CHARM}-${CONTAINER}.log
-              done
-          done
-        if: always()
-
-      - name: Get juju debug-log
-        run: juju debug-log -m kubeflow --replay --no-tail | tee /tmp/juju-debug-log.log
-        if: failure()
-
-      - name: Upload debug artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-run-artifacts
-          path: |
-            /tmp/juju*.log
-            /tmp/kubectl-logs*.log
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@chore/update-dump-charm-debug-artifacts
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,10 +264,10 @@ jobs:
         if: always()
 
       - name: Collect charm debug artifacts
-        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@chore/update-dump-charm-debug-artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         with:
-          artifact-prefix: ${{ matrix.charm }}
-        if: always()
+          artifact-prefix: ${{ matrix.test-type }}-${{ matrix.charm }}
+        if: failure()
 
 
   test-bundle:
@@ -334,5 +334,7 @@ jobs:
         if: always()
 
       - name: Collect charm debug artifacts
-        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@chore/update-dump-charm-debug-artifacts
-        if: always()
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        with:
+          artifact-prefix: ${{ matrix.test-type }}-bundle
+        if: failure()


### PR DESCRIPTION
This PR bumps `actions/checkout` and `actions/download-artifact` to newer versions using Node 24.
This PR also always prints `juju status`, with relations.