### PR TITLE
chore: bump actions to newer versions (backport #906 and #909)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,24 +22,6 @@ on:
         value: ${{ jobs.get-charm-paths-track.outputs.track }}
 
 jobs:
-  lib-check:
-    name: Check libraries
-    strategy:
-      matrix:
-        charm:
-          - kfp-api
-          - kfp-metadata-writer
-          - kfp-persistence
-          - kfp-profile-controller
-          - kfp-schedwf
-          - kfp-ui
-          - kfp-viewer
-          - kfp-viz
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: ./charms/${{ matrix.charm }}
-
   lint-bundle:
     name: Lint Bundle Tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - run: pipx install tox
-      - run: tox -e lint
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e lint
 
   lint:
     name: Lint
@@ -64,9 +68,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-lint
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-lint
 
   unit:
     name: Unit tests
@@ -84,9 +92,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-unit
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-unit
 
   terraform-checks:
     name: Terraform
@@ -116,12 +128,15 @@ jobs:
       charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
       track: ${{ steps.determine-track.outputs.track }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Get paths for all charms in this repo
         id: get-charm-paths
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
+
       - name: Determine track
         id: determine-track
         shell: python
@@ -198,7 +213,10 @@ jobs:
       - name: Maximise GH runner space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -212,7 +230,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -227,11 +245,16 @@ jobs:
           # We need to find a better way to dynamically get this value
           tox -e ${{ matrix.charm }}-integration -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
+      - name: Get juju status
+        run: juju status --relations
+        if: always()
+
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         with:
-          artifact-prefix: ${{ matrix.charm }}
+          artifact-prefix: ${{ matrix.test-type }}-${{ matrix.charm }}
         if: failure()
+
 
   test-bundle:
     name: Test the bundle
@@ -250,7 +273,10 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -264,7 +290,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -275,16 +301,12 @@ jobs:
           juju add-model kubeflow
           tox -e bundle-integration -- --model=kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=./tests/integration/bundles/bundle.yaml.j2
 
-      - name: Get all
-        run: kubectl get all -A
-        if: failure()
-
       - name: Get juju status
-        run: juju status
-        if: failure()
+        run: juju status --relations
+        if: always()
 
-      # Collect debug artefacts only on failure || cancelled as the CI for this repository
-      # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: failure() || cancelled()
+        with:
+          artifact-prefix: ${{ matrix.test-type }}-bundle
+        if: failure()


### PR DESCRIPTION
# Description
Backport of #906 and #909 to `track/2.5`.