### PR TITLE
chore: bump actions to newer versions (backport #909)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - run: pipx install tox
-      - run: tox -e lint
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e lint
 
   lint:
     name: Lint
@@ -46,9 +50,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-lint
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-lint
 
   unit:
     name: Unit tests
@@ -66,9 +74,13 @@ jobs:
           - kfp-viewer
           - kfp-viz
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx install tox
-      - run: tox -e ${{ matrix.charm }}-unit
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - run: |
+          pipx install tox
+          tox -e ${{ matrix.charm }}-unit
 
   get-charm-paths-track:
     name: Get charm paths and track
@@ -78,12 +90,15 @@ jobs:
       track: ${{ steps.determine-track.outputs.track }}
       channel: ${{ steps.determine-track.outputs.channel }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Get paths for all charms in this repo
         id: get-charm-paths
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
+
       - name: Determine track
         id: determine-track
         shell: python
@@ -204,7 +219,10 @@ jobs:
       - name: Maximise GH runner space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -218,7 +236,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -241,11 +259,16 @@ jobs:
           # We need to find a better way to dynamically get this value
           tox -e ${{ matrix.charm }}-${{ matrix.test-type }} -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@24.04-amd64.charm
 
+      - name: Get juju status
+        run: juju status --relations
+        if: always()
+
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         with:
-          artifact-prefix: ${{ matrix.charm }}
+          artifact-prefix: ${{ matrix.test-type }}-${{ matrix.charm }}
         if: failure()
+
 
   test-bundle:
     name: Test the bundle
@@ -270,7 +293,10 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Install dependencies
         run: pipx install tox
 
@@ -292,7 +318,7 @@ jobs:
       - name: Download packed charm(s)
         id: download-charms
         timeout-minutes: 5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -303,16 +329,12 @@ jobs:
           juju add-model kubeflow
           tox -e bundle-${{ matrix.test-type }} -- --model=kubeflow --charms-path=${{ github.workspace }}/charms/ --bundle=${{ matrix.bundle }}
 
-      - name: Get all
-        run: kubectl get all -A
-        if: failure()
-
       - name: Get juju status
-        run: juju status
-        if: failure()
+        run: juju status --relations
+        if: always()
 
-      # Collect debug artefacts only on failure || cancelled as the CI for this repository
-      # in particular struggles with storage limitations.
       - name: Collect charm debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: failure() || cancelled()
+        with:
+          artifact-prefix: ${{ matrix.test-type }}-bundle
+        if: failure()


### PR DESCRIPTION
# Description
Backport of #909 to `track/2.16`.