### PR TITLE
chore: add track/2.16 to automatic backport tracks

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,3 +1,4 @@
 automatic_backport_tracks:
+  -   track/2.16
   -   track/2.15
   -   track/2.5


### PR DESCRIPTION
## Summary
This PR updates `automatic_backport_tracks.yaml` to the newest tracks that we use in our bundles.

Base issue: https://github.com/canonical/bundle-kubeflow/issues/1443