### PR TITLE
fix: Remove unused kfp-ui endpoint

### DIFF
--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -104,20 +104,3 @@ requires:
   logging:
     interface: loki_push_api
     optional: true
-provides:
-  kfp-ui:
-    interface: k8s-service
-    schema:
-      v1:
-        provides:
-          type: object
-          properties:
-            service-name:
-              type: string
-            service-port:
-              type: string
-          required:
-          - service-name
-          - service-port
-    versions: [v1]
-    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml

--- a/charms/kfp-ui/src/charm.py
+++ b/charms/kfp-ui/src/charm.py
@@ -157,19 +157,6 @@ class KfpUiOperator(CharmBase):
             depends_on=[self.leadership_gate],
         )
 
-        self.kfp_ui_relation = self.charm_reconciler.add(
-            SdiRelationBroadcasterComponent(
-                charm=self,
-                name="relation:kfp-ui",
-                relation_name="kfp-ui",
-                data_to_send={
-                    "service-name": f"{self.model.app.name}.{self.model.name}",
-                    "service-port": self.model.config["http-port"],
-                },
-            ),
-            depends_on=[self.leadership_gate],
-        )
-
         self.object_storage_relation = self.charm_reconciler.add(
             component=SdiRelationDataReceiverComponent(
                 charm=self,

--- a/charms/kfp-ui/tests/unit/test_operator.py
+++ b/charms/kfp-ui/tests/unit/test_operator.py
@@ -159,38 +159,6 @@ def test_ingress_relation_with_related_app(harness, mocked_kubernetes_service_pa
     assert_relation_data_send_as_expected(harness, expected_relation_data, relation_ids_to_assert)
 
 
-def test_kfp_ui_relation_with_related_app(harness, mocked_kubernetes_service_patch):
-    """Test that the kfp-ui relation sends data to related apps and goes Active."""
-    # Arrange
-    harness.set_leader(True)  # needed to write to an SDI relation
-    model = "model"
-    harness.set_model_name(model)
-    harness.begin()
-
-    # Mock:
-    # * leadership_gate to be active and executed
-    harness.charm.leadership_gate.get_status = MagicMock(return_value=ActiveStatus())
-
-    expected_relation_data = {
-        "_supported_versions": ["v1"],
-        "data": render_kfp_ui_data(
-            app_name=harness.model.app.name,
-            model_name=model,
-            port=harness.model.config["http-port"],
-        ),
-    }
-
-    # Act
-    # Add one relation with data.  This should trigger a charm reconciliation due to
-    # relation-changed.
-    relation_metadata = add_sdi_relation_to_harness(harness, "kfp-ui", other_app="o1", data={})
-    relation_ids_to_assert = [relation_metadata.rel_id]
-
-    # Assert
-    assert isinstance(harness.charm.kfp_ui_relation.status, ActiveStatus)
-    assert_relation_data_send_as_expected(harness, expected_relation_data, relation_ids_to_assert)
-
-
 def assert_relation_data_send_as_expected(harness, expected_relation_data, rel_ids_to_assert):
     """Asserts that we have sent the expected data to the given relations."""
     # Assert on the data we sent out to the other app for each relation.
@@ -263,12 +231,4 @@ def render_ingress_data(service, port) -> dict:
         "rewrite": "/pipeline",
         "service": service,
         "port": int(port),
-    }
-
-
-def render_kfp_ui_data(app_name, model_name, port) -> dict:
-    """Returns typical data for the kfp-ui relation."""
-    return {
-        "service-name": f"{app_name}.{model_name}",
-        "service-port": str(port),
     }


### PR DESCRIPTION
## Summary
- Backports the endpoint removal from #888 onto `track/2.5` as a clean commit.
- Removes the obsolete `kfp-ui` relation from `metadata.yaml`, its broadcaster component from `charm.py`, and the corresponding unit test/helper.
- Leaves out the `BACKPORT-CONFLICT` commit and does not include service-mesh relation changes.

## Testing
- `tox -e lint,unit` from `charms/kfp-ui`