### PR TITLE
chore: integrate rock image persistenceagent:2.15.0-da3eb7e-20260608161305

### DIFF
--- a/charms/kfp-persistence/metadata.yaml
+++ b/charms/kfp-persistence/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/persistenceagent:2.15.0-d64b349
+    upstream-source: docker.io/dariofaccin/persistenceagent:2.15.0-da3eb7e-20260608161305
 requires:
   kfp-api:
     interface: k8s-service


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-persistence/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-persistence/src/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  

