### PR TITLE
chore: integrate rock image frontend:2.15.0-da3eb7e-20260608161316

### DIFF
--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,4 +1,4 @@
 {
     "visualization_server": "docker.io/charmedkubeflow/visualization-server:2.15.0-e63a3fc",
-    "frontend": "docker.io/charmedkubeflow/frontend:2.15.0-890e0cc"
+    "frontend": "docker.io/dariofaccin/frontend:2.15.0-da3eb7e-20260608161316"
 }

--- a/charms/kfp-ui/metadata.yaml
+++ b/charms/kfp-ui/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for ml-pipeline-ui
     # The container's command and `user` need to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/frontend:2.15.0-6b3223a
+    upstream-source: docker.io/dariofaccin/frontend:2.15.0-da3eb7e-20260608161316
 requires:
   object-storage:
     interface: object-storage


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-profile-controller/src/default-custom-images.json`
  - **Path**: `frontend`

- **File**: `charms/kfp-ui/metadata.yaml`
  - **Path**: `resources.ml-pipeline-ui.upstream-source`



## ⚙️ Updated Service Specifications

The following service-spec files were patched:


- **File**: `charms/kfp-ui/src/service-config.yaml`
  
  
  - Set **command** at `command` → `node /server/dist/server.js /client/ 3000
`
  



