### PR TITLE
chore: integrate rock image visualization-server:2.15.0-da3eb7e-20260608161307

### DIFF
--- a/charms/kfp-profile-controller/src/default-custom-images.json
+++ b/charms/kfp-profile-controller/src/default-custom-images.json
@@ -1,4 +1,4 @@
 {
-    "visualization_server": "docker.io/charmedkubeflow/visualization-server:2.15.0-e63a3fc",
+    "visualization_server": "docker.io/dariofaccin/visualization-server:2.15.0-da3eb7e-20260608161307",
     "frontend": "docker.io/charmedkubeflow/frontend:2.15.0-890e0cc"
 }

--- a/charms/kfp-viz/metadata.yaml
+++ b/charms/kfp-viz/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: OCI image for ml-pipeline-visualizationserver
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/visualization-server:2.15.0-e63a3fc
+    upstream-source: docker.io/dariofaccin/visualization-server:2.15.0-da3eb7e-20260608161307
 provides:
   kfp-viz:
     interface: k8s-service


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-profile-controller/src/default-custom-images.json`
  - **Path**: `visualization_server`

- **File**: `charms/kfp-viz/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-viz/src/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  

