### PR TITLE
chore: integrate rock image scheduledworkflow:2.15.0-da3eb7e-20260608192234

### DIFF
--- a/charms/kfp-schedwf/metadata.yaml
+++ b/charms/kfp-schedwf/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/scheduledworkflow:2.15.0-2d3038c
+    upstream-source: docker.io/dariofaccin/scheduledworkflow:2.15.0-da3eb7e-20260608192234
 requires:
   logging:
     interface: loki_push_api


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-schedwf/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-schedwf/src/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  

