### PR TITLE
chore: integrate rock image kfp-launcher:2.15.0-da3eb7e-20260608192241

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -52,7 +52,7 @@ options:
   launcher-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.15.0/backend/src/v2/compiler/argocompiler/container.go#L44
-    default: "docker.io/charmedkubeflow/kfp-launcher:2.15.0-a7d4db6"
+    default: "docker.io/dariofaccin/kfp-launcher:2.15.0-da3eb7e-20260608192241"
     description: Launcher image used during a pipeline's steps.
   driver-image:
     type: string


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-api/config.yaml`
  - **Path**: `options.launcher-image.default`




