### PR TITLE
chore: integrate rock image kfp-driver:2.15.0-da3eb7e-20260608192234

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -57,7 +57,7 @@ options:
   driver-image:
     type: string
     # Source: https://github.com/kubeflow/pipelines/blob/2.15.0/backend/src/v2/compiler/argocompiler/container.go#L45
-    default: "docker.io/charmedkubeflow/kfp-driver:2.15.0-e7683d7"
+    default: "docker.io/dariofaccin/kfp-driver:2.15.0-da3eb7e-20260608192234"
     description: Driver image used during a pipeline's steps.
   log-level:
     type: string


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-api/config.yaml`
  - **Path**: `options.driver-image.default`




