### PR TITLE
chore: integrate rock image viewer-crd-controller:2.15.0-da3eb7e-20260608192233

### DIFF
--- a/charms/kfp-viewer/metadata.yaml
+++ b/charms/kfp-viewer/metadata.yaml
@@ -15,7 +15,7 @@ resources:
     type: oci-image
     description: OCI image for KFP Viewer
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/viewer-crd-controller:2.15.0-4add869
+    upstream-source: docker.io/dariofaccin/viewer-crd-controller:2.15.0-da3eb7e-20260608192233
 requires:
   logging:
     interface: loki_push_api


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-viewer/metadata.yaml`
  - **Path**: `resources.kfp-viewer-image.upstream-source`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-viewer/src/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  

