### PR TITLE
chore: integrate rock image metadata-writer:2.15.0-da3eb7e-20260608192233

### DIFF
--- a/charms/kfp-metadata-writer/metadata.yaml
+++ b/charms/kfp-metadata-writer/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: OCI image for KFP Metadata Writer
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/metadata-writer:2.15.0-7fc119b
+    upstream-source: docker.io/dariofaccin/metadata-writer:2.15.0-da3eb7e-20260608192233
 requires:
   grpc:
     interface: k8s-service


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-metadata-writer/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-metadata-writer/src/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  

