### PR TITLE
fix: reintroduce kfp-api-principal config

### DIFF
--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -35,4 +35,4 @@ options:
       DEPRECATED: use `kfp_api_service_account_name` instead.
       The principal for the KFP API service account.
       This is used in the AuthorizationPolicy that gets created in the sync.py script.
-      Cannot be set together with `kfp_api_service_account_name`.
+      To use this option, `kfp_api_service_account_name` must be set to an empty string.

--- a/charms/kfp-profile-controller/config.yaml
+++ b/charms/kfp-profile-controller/config.yaml
@@ -28,3 +28,11 @@ options:
     description: >
       The Kubernetes service account name used by the kfp-api charm.
       This should match the application name used when deploying the kfp-api charm.
+  kfp-api-principal:
+    type: string
+    default: ""
+    description: >
+      DEPRECATED: use `kfp_api_service_account_name` instead.
+      The principal for the KFP API service account.
+      This is used in the AuthorizationPolicy that gets created in the sync.py script.
+      Cannot be set together with `kfp_api_service_account_name`.

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -62,8 +62,6 @@ KFP_IMAGES_VERSION = "2.16.0"  # Remember to change this version also in default
 METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
-# Default value of the `kfp_api_service_account_name` config option, must match config.yaml
-DEFAULT_KFP_API_SERVICE_ACCOUNT_NAME = "kfp-api"
 
 HOOKS_PATH = Path("/var/lib/pebble/default")
 
@@ -112,7 +110,7 @@ class KfpProfileControllerOperator(CharmBase):
                 parse_images_config(self.model.config["custom_images"]),
             )
             # Validate the principal-related config early so the unit goes to BlockedStatus
-            # if both `kfp-api-principal` and `kfp_api_service_account_name` are set.
+            # if both `kfp-api-principal` and `kfp_api_service_account_name` are non-empty.
             self._get_kfp_api_principal()
         except ErrorWithStatus as e:
             self.unit.status = e.status
@@ -247,17 +245,17 @@ class KfpProfileControllerOperator(CharmBase):
 
         Raises:
             ErrorWithStatus: if both `kfp-api-principal` and `kfp_api_service_account_name`
-                are set.
+                are non-empty.
         """
         kfp_api_principal = self.model.config["kfp-api-principal"]
         kfp_api_service_account_name = self.model.config["kfp_api_service_account_name"]
 
         if kfp_api_principal:
-            if kfp_api_service_account_name != DEFAULT_KFP_API_SERVICE_ACCOUNT_NAME:
+            if kfp_api_service_account_name:
                 raise ErrorWithStatus(
                     "Cannot set both `kfp-api-principal` and `kfp_api_service_account_name`. "
-                    "Use only `kfp_api_service_account_name` as `kfp-api-principal` is "
-                    "deprecated.",
+                    "The `kfp-api-principal` option is deprecated; to use it, set "
+                    "`kfp_api_service_account_name` to an empty string.",
                     BlockedStatus,
                 )
             logger.warning(

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -62,6 +62,8 @@ KFP_IMAGES_VERSION = "2.16.0"  # Remember to change this version also in default
 METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
+# Default value of the `kfp_api_service_account_name` config option, must match config.yaml
+DEFAULT_KFP_API_SERVICE_ACCOUNT_NAME = "kfp-api"
 
 HOOKS_PATH = Path("/var/lib/pebble/default")
 
@@ -109,6 +111,9 @@ class KfpProfileControllerOperator(CharmBase):
                 DEFAULT_IMAGES,
                 parse_images_config(self.model.config["custom_images"]),
             )
+            # Validate the principal-related config early so the unit goes to BlockedStatus
+            # if both `kfp-api-principal` and `kfp_api_service_account_name` are set.
+            self._get_kfp_api_principal()
         except ErrorWithStatus as e:
             self.unit.status = e.status
             return
@@ -217,8 +222,7 @@ class KfpProfileControllerOperator(CharmBase):
                     VISUALIZATION_SERVER_TAG=self.images["visualization_server__version"],
                     FRONTEND_IMAGE=self.images["frontend__image"],
                     FRONTEND_TAG=self.images["frontend__version"],
-                    KFP_API_PRINCIPAL=f"cluster.local/ns/{self.model.name}/sa/"
-                    f"{self.model.config['kfp_api_service_account_name']}",
+                    KFP_API_PRINCIPAL=self._get_kfp_api_principal(),
                     AMBIENT_ENABLED=self.service_mesh_component.component.ambient_mesh_enabled,
                     HOOKS_PATH=HOOKS_PATH,
                 ),
@@ -233,6 +237,36 @@ class KfpProfileControllerOperator(CharmBase):
 
         self.charm_reconciler.install_default_event_handlers()
         self._logging = LogForwarder(charm=self)
+
+    def _get_kfp_api_principal(self) -> str:
+        """Return the KFP API principal to use in the AuthorizationPolicy.
+
+        If the deprecated `kfp-api-principal` config option is set, it is used directly.
+        Otherwise, the principal is computed from the `kfp_api_service_account_name` config
+        option and the model namespace.
+
+        Raises:
+            ErrorWithStatus: if both `kfp-api-principal` and `kfp_api_service_account_name`
+                are set.
+        """
+        kfp_api_principal = self.model.config["kfp-api-principal"]
+        kfp_api_service_account_name = self.model.config["kfp_api_service_account_name"]
+
+        if kfp_api_principal:
+            if kfp_api_service_account_name != DEFAULT_KFP_API_SERVICE_ACCOUNT_NAME:
+                raise ErrorWithStatus(
+                    "Cannot set both `kfp-api-principal` and `kfp_api_service_account_name`. "
+                    "Use only `kfp_api_service_account_name` as `kfp-api-principal` is "
+                    "deprecated.",
+                    BlockedStatus,
+                )
+            logger.warning(
+                "The `kfp-api-principal` config option is deprecated and will be removed in a "
+                "future release. Use `kfp_api_service_account_name` instead."
+            )
+            return kfp_api_principal
+
+        return f"cluster.local/ns/{self.model.name}/sa/{kfp_api_service_account_name}"
 
     def get_images(
         self, default_images: Dict[str, str], custom_images: Dict[str, str]

--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -405,7 +405,7 @@ async def test_sync_webhook_before_config_changes(
         lightkube_client.get(resource, name=name, namespace=profile)
 
 
-async def test_default_config_for_deafult_pipeline_root(
+async def test_default_config_for_default_pipeline_root(
     lightkube_client: lightkube.Client, profile: str
 ):
     """Test that the default config for the default pipeline root is applied as intended."""
@@ -423,14 +423,14 @@ async def test_default_config_for_deafult_pipeline_root(
     )
 
 
-async def test_first_change_to_config_for_deafult_pipeline_root(
+async def test_first_change_to_config_for_default_pipeline_root(
     ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
 ):
     """Test that a first config change for the default pipeline root results in a ConfigMap."""
-    updated_deafult_pipeline_root = "s3://whatever-minio-bucket/whatever/minio/path"
+    updated_default_pipeline_root = "s3://whatever-minio-bucket/whatever/minio/path"
 
     await ops_test.model.applications[CHARM_NAME].set_config(
-        {CONFIG_NAME_FOR_DEFAULT_PIPELINE_ROOT: updated_deafult_pipeline_root}
+        {CONFIG_NAME_FOR_DEFAULT_PIPELINE_ROOT: updated_default_pipeline_root}
     )
     await ops_test.model.wait_for_idle(
         apps=[CHARM_NAME], status="active", raise_on_blocked=True, timeout=300
@@ -448,18 +448,18 @@ async def test_first_change_to_config_for_deafult_pipeline_root(
     )
     assert (
         kfp_launcher_configmap.data[KFP_LAUNCHER_CONFIGMAP_KEY_FOR_DEFAULT_PIPELINE_ROOT]
-        == updated_deafult_pipeline_root
+        == updated_default_pipeline_root
     )
 
 
-async def test_yet_another_change_to_config_for_deafult_pipeline_root(
+async def test_yet_another_change_to_config_for_default_pipeline_root(
     ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
 ):
     """Test that another config change for the default pipeline root updates the ConfigMap."""
-    updated_deafult_pipeline_root = "s3://whatever-s3-bucket/whatever/s3/path"
+    updated_default_pipeline_root = "s3://whatever-s3-bucket/whatever/s3/path"
 
     await ops_test.model.applications[CHARM_NAME].set_config(
-        {CONFIG_NAME_FOR_DEFAULT_PIPELINE_ROOT: updated_deafult_pipeline_root}
+        {CONFIG_NAME_FOR_DEFAULT_PIPELINE_ROOT: updated_default_pipeline_root}
     )
     await ops_test.model.wait_for_idle(
         apps=[CHARM_NAME], status="active", raise_on_blocked=True, timeout=300
@@ -477,7 +477,7 @@ async def test_yet_another_change_to_config_for_deafult_pipeline_root(
     )
     assert (
         kfp_launcher_configmap.data[KFP_LAUNCHER_CONFIGMAP_KEY_FOR_DEFAULT_PIPELINE_ROOT]
-        == updated_deafult_pipeline_root
+        == updated_default_pipeline_root
     )
 
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -204,6 +204,25 @@ async def test_insecure_authorization_policy_is_missing(
     assert excinfo.value.response.status_code == 404
 
 
+# Targeted for ambient integration
+@pytest.mark.abort_on_fail
+async def test_kfp_api_principal_changed(
+    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
+):
+    """Test that the principal in the AuthorizationPolicy changes on config-change."""
+    new_principal = "test"
+    await ops_test.model.applications[CHARM_NAME].set_config({"kfp-api-principal": new_principal})
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=600)
+
+    # ensure the AuthorizationPolicy in Profile is updated
+    policy = get_authorization_policy(AMBIENT_AP_NAME, profile, lightkube_client)
+    assert policy["spec"]["rules"][0]["from"][0]["source"]["principals"][0] == new_principal
+
+    # reset the deprecated config option to its default
+    await ops_test.model.applications[CHARM_NAME].set_config({"kfp-api-principal": ""})
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=600)
+
+
 @tenacity.retry(
     wait=wait_exponential(multiplier=1, min=1, max=5),
     stop=stop_after_delay(60 * 2),

--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -211,7 +211,12 @@ async def test_kfp_api_principal_changed(
 ):
     """Test that the principal in the AuthorizationPolicy changes on config-change."""
     new_principal = "test"
-    await ops_test.model.applications[CHARM_NAME].set_config({"kfp-api-principal": new_principal})
+    await ops_test.model.applications[CHARM_NAME].set_config(
+        {
+            "kfp-api-principal": new_principal,
+            "kfp_api_service_account_name": "",
+        }
+    )
     await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=600)
 
     # ensure the AuthorizationPolicy in Profile is updated

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -327,6 +327,61 @@ def test_pebble_services_updated_when_kfp_api_service_account_name_changes(
     assert environment == generate_expected_environment(harness.model.name, kfp_api_sa=custom_sa)
 
 
+def test_pebble_services_with_deprecated_kfp_api_principal(
+    harness: Harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+):
+    """Test that the deprecated `kfp-api-principal` config is used directly when set."""
+    # Arrange
+    custom_principal = "cluster.local/ns/some-namespace/sa/some-sa"
+    harness.update_config({"kfp-api-principal": custom_principal})
+    expected_environment = generate_expected_environment(harness.model.name)
+    expected_environment["KFP_API_PRINCIPAL"] = custom_principal
+    harness.begin()
+    harness.set_can_connect("kfp-profile-controller", True)
+
+    # Mock:
+    # * leadership_gate to have get_status=>Active
+    # * object_storage_relation to return mock data, making the item go active
+    # * kubernetes_resources to have get_status=>Active
+    harness.charm.leadership_gate.get_status = MagicMock(return_value=ActiveStatus())
+    harness.charm.object_storage_relation.component.get_data = MagicMock(
+        return_value=MOCK_OBJECT_STORAGE_DATA
+    )
+    harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())
+
+    # Act
+    harness.charm.on.install.emit()
+
+    # Assert
+    container = harness.charm.unit.get_container("kfp-profile-controller")
+    environment = container.get_plan().services["kfp-profile-controller"].environment
+    assert environment == expected_environment
+
+
+def test_blocked_when_kfp_api_principal_and_service_account_name_both_set(
+    harness: Harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+):
+    """Test that the unit goes to blocked when both principal and service account are set."""
+    # Arrange
+    harness.update_config(
+        {
+            "kfp-api-principal": "cluster.local/ns/some-namespace/sa/some-sa",
+            "kfp_api_service_account_name": "my-custom-kfp-api",
+        }
+    )
+
+    # Act
+    harness.begin()
+
+    # Assert
+    assert isinstance(harness.model.unit.status, BlockedStatus)
+    assert harness.charm.model.unit.status.message.startswith("Cannot set both")
+
+
 def test_custom_images_config_with_incorrect_config(
     harness: Harness, mocked_lightkube_client, mocked_kubernetes_service_patch
 ):

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -335,8 +335,13 @@ def test_pebble_services_with_deprecated_kfp_api_principal(
     """Test that the deprecated `kfp-api-principal` config is used directly when set."""
     # Arrange
     custom_principal = "cluster.local/ns/some-namespace/sa/some-sa"
-    harness.update_config({"kfp-api-principal": custom_principal})
+    # When `kfp-api-principal` is set, `kfp_api_service_account_name` must be empty.
+    harness.update_config(
+        {"kfp-api-principal": custom_principal, "kfp_api_service_account_name": ""}
+    )
     expected_environment = generate_expected_environment(harness.model.name)
+    # The principal is taken directly from the deprecated config, not computed from the
+    # service account name.
     expected_environment["KFP_API_PRINCIPAL"] = custom_principal
     harness.begin()
     harness.set_can_connect("kfp-profile-controller", True)
@@ -366,7 +371,8 @@ def test_blocked_when_kfp_api_principal_and_service_account_name_both_set(
     mocked_kubernetes_service_patch,
 ):
     """Test that the unit goes to blocked when both principal and service account are set."""
-    # Arrange
+    # Arrange: setting `kfp-api-principal` while `kfp_api_service_account_name` is non-empty
+    # (here, its default value) is not allowed.
     harness.update_config(
         {
             "kfp-api-principal": "cluster.local/ns/some-namespace/sa/some-sa",


### PR DESCRIPTION
This PR reintroduces `kfp-api-principal` config option, allowing the refresh from older versions of the `kfp-profile-controller` charm where this option might be set.

If the configuration option is set, then its value is used to populate the env variable `KFP_API_PRINCIPAL`.
If the configuration option is not set, then the env variable `KFP_API_PRINCIPAL` is dinamically constructed by the charm using the model name and the `kfp_api_service_account_name` config option.

**Note**: setting a custom `kfp_api_service_account_name` and `kfp-api-principal` results in the charm going into Blocked status.

This PR closes #946.