### PR TITLE
fix: increase retry period for validate_profile_deployments_with_custom_images

### DIFF
--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -326,9 +326,11 @@ def validate_profile_resources(
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
 
+# Retry for 90 seconds since the metacontroller's `resyncPeriodSeconds` is
+# currently 60s, so at worst it will take 60s for the resync to be triggered.
 @retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
-    stop=stop_after_delay(60),
+    stop=stop_after_delay(90),
     reraise=True,
 )
 def validate_profile_deployments_with_custom_images(

--- a/charms/kfp-profile-controller/tests/integration/test_charm_object_storage.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_object_storage.py
@@ -232,9 +232,11 @@ def validate_profile_resources(
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
 
+# Retry for 90 seconds since the metacontroller's `resyncPeriodSeconds` is
+# currently 60s, so at worst it will take 60s for the resync to be triggered.
 @retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
-    stop=stop_after_delay(60),
+    stop=stop_after_delay(90),
     reraise=True,
 )
 def validate_profile_deployments_with_custom_images(

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -321,9 +321,11 @@ def validate_profile_resources(
     assert expected_label_value == namespace.metadata.labels[expected_label]
 
 
+# Retry for 90 seconds since the metacontroller's `resyncPeriodSeconds` is
+# currently 60s, so at worst it will take 60s for the resync to be triggered.
 @retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
-    stop=stop_after_delay(60),
+    stop=stop_after_delay(90),
     reraise=True,
 )
 def validate_profile_deployments_with_custom_images(


### PR DESCRIPTION
## Summary
- Increase the timeout for the `validate_profile_deployments_with_custom_images` function to 90 seconds for both `test_charm` and `test_charm_ambient`

## Notes
Because the metacontroller's `resyncPeriodSeconds` is 60 seconds, that means that it can theoretically take up to 60 seconds for the `sync.py` hook to be triggered. I added 30 seconds for buffer, since this won't affect successful runs

Closes #951