### PR TITLE
feat: Add config-maps and secrets relation in kfp-profile-controller

### DIFF
--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -160,8 +160,7 @@ def get_settings_from_env(controller_port=None,
 
     # When integrated with resource-dispatcher (over the `secrets` / `configmaps` relations),
     # the `mlpipeline-minio-artifact` Secret and/or the `kfp-launcher` ConfigMap are created by
-    # resource-dispatcher instead of by this webhook.  These flags default to "true" (i.e. this
-    # webhook creates the resources) to preserve the standalone behaviour.
+    # resource-dispatcher instead of by this webhook.
     settings["manage_minio_secret"] = os.environ.get("MANAGE_MINIO_SECRET", "true") == "true"
     settings["manage_kfp_launcher_configmap"] = \
         os.environ.get("MANAGE_KFP_LAUNCHER_CONFIGMAP", "true") == "true"
@@ -207,9 +206,9 @@ def server_factory(visualization_server_image,
             # This means that we have to always update the provider to use our wanted endpoint
             # We set this by using the `kfp-launcher` configmap, as specified in:
             # https://www.kubeflow.org/docs/components/pipelines/operator-guides/configure-object-store/#s3-and-s3-compatible-provider
+            
             # When integrated with resource-dispatcher over the `configmaps` relation, the
-            # `kfp-launcher` ConfigMap is created by resource-dispatcher instead, so it is not
-            # included here (and is excluded from the expected ConfigMap count).
+            # `kfp-launcher` ConfigMap is created by resource-dispatcher instead.
             desired_configmap_count = 2 if manage_kfp_launcher_configmap else 1
             desired_resources = []
 

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -158,9 +158,10 @@ def get_settings_from_env(controller_port=None,
 
     settings["ambient_mesh_enabled"] = os.environ.get("AMBIENT_ENABLED", "false") == "true"
 
-    # When integrated with resource-dispatcher (over the `secrets` / `configmaps` relations),
-    # the `mlpipeline-minio-artifact` Secret and/or the `kfp-launcher` ConfigMap are created by
-    # resource-dispatcher instead of by this webhook.
+    # If integrated with resource-dispatcher over certain endpoints, the following resources
+    # should be created by resource-dispatcher instead of this webhook:
+    # - `secrets` endpoint -> `mlpipeline-minio-artifact` Secret
+    # - `config-maps` endpoint -> `kfp-launcher` ConfigMap
     settings["manage_minio_secret"] = os.environ.get("MANAGE_MINIO_SECRET", "true") == "true"
     settings["manage_kfp_launcher_configmap"] = \
         os.environ.get("MANAGE_KFP_LAUNCHER_CONFIGMAP", "true") == "true"

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -157,6 +157,14 @@ def get_settings_from_env(controller_port=None,
     )
 
     settings["ambient_mesh_enabled"] = os.environ.get("AMBIENT_ENABLED", "false") == "true"
+
+    # When integrated with resource-dispatcher (over the `secrets` / `configmaps` relations),
+    # the `mlpipeline-minio-artifact` Secret and/or the `kfp-launcher` ConfigMap are created by
+    # resource-dispatcher instead of by this webhook.  These flags default to "true" (i.e. this
+    # webhook creates the resources) to preserve the standalone behaviour.
+    settings["manage_minio_secret"] = os.environ.get("MANAGE_MINIO_SECRET", "true") == "true"
+    settings["manage_kfp_launcher_configmap"] = \
+        os.environ.get("MANAGE_KFP_LAUNCHER_CONFIGMAP", "true") == "true"
     # - - - - - - - - - - - - - - - - - -
 
     return settings
@@ -170,7 +178,8 @@ def server_factory(visualization_server_image,
                    metadata_grpc_service_host, metadata_grpc_service_port,
                    kfp_api_principal, ambient_mesh_enabled,
                    minio_ssl=False, minio_region="us-east-1",
-                   kfp_default_pipeline_root=None, url="", controller_port=8080):
+                   kfp_default_pipeline_root=None, url="", controller_port=8080,
+                   manage_minio_secret=True, manage_kfp_launcher_configmap=True):
     """
     Returns an HTTPServer populated with Handler with customized settings
     """
@@ -198,7 +207,10 @@ def server_factory(visualization_server_image,
             # This means that we have to always update the provider to use our wanted endpoint
             # We set this by using the `kfp-launcher` configmap, as specified in:
             # https://www.kubeflow.org/docs/components/pipelines/operator-guides/configure-object-store/#s3-and-s3-compatible-provider
-            desired_configmap_count = 2
+            # When integrated with resource-dispatcher over the `configmaps` relation, the
+            # `kfp-launcher` ConfigMap is created by resource-dispatcher instead, so it is not
+            # included here (and is excluded from the expected ConfigMap count).
+            desired_configmap_count = 2 if manage_kfp_launcher_configmap else 1
             desired_resources = []
 
             # The MinIO/S3 endpoint is built by the charm (see ObjectStorageValidatorComponent and
@@ -226,21 +238,23 @@ def server_factory(visualization_server_image,
             if kfp_default_pipeline_root:
                 configmap_data["defaultPipelineRoot"] = kfp_default_pipeline_root
 
-            desired_resources += [{
-                "apiVersion": "v1",
-                "kind": "ConfigMap",
-                "metadata": {
-                    "name": "kfp-launcher",
-                    "namespace": namespace,
-                },
-                "data": configmap_data,
-            }]
+            if manage_kfp_launcher_configmap:
+                desired_resources += [{
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "kfp-launcher",
+                        "namespace": namespace,
+                    },
+                    "data": configmap_data,
+                }]
 
 
             # Compute status based on observed state.
+            desired_secret_count = 1 if manage_minio_secret else 0
             desired_status = {
                 "kubeflow-pipelines-ready":
-                    len(attachments["Secret.v1"]) == 1 and
+                    len(attachments["Secret.v1"]) == desired_secret_count and
                     len(attachments["ConfigMap.v1"]) == desired_configmap_count and
                     len(attachments["Deployment.apps/v1"]) == 2 and
                     len(attachments["Service.v1"]) == 2 and
@@ -567,18 +581,21 @@ def server_factory(visualization_server_image,
             print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
             print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))
             # Moved after the print argument because this is sensitive data.
-            desired_resources.append({
-                "apiVersion": "v1",
-                "kind": "Secret",
-                "metadata": {
-                    "name": "mlpipeline-minio-artifact",
-                    "namespace": namespace,
-                },
-                "data": {
-                    "accesskey": minio_access_key,
-                    "secretkey": minio_secret_key,
-                },
-            })
+            # When integrated with resource-dispatcher over the `secrets` relation, the
+            # `mlpipeline-minio-artifact` Secret is created by resource-dispatcher instead.
+            if manage_minio_secret:
+                desired_resources.append({
+                    "apiVersion": "v1",
+                    "kind": "Secret",
+                    "metadata": {
+                        "name": "mlpipeline-minio-artifact",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "accesskey": minio_access_key,
+                        "secretkey": minio_secret_key,
+                    },
+                })
 
             return {"status": desired_status, "attachments": desired_resources}
 

--- a/charms/kfp-profile-controller/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
+++ b/charms/kfp-profile-controller/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
@@ -1,0 +1,507 @@
+"""KubernetesManifests Library
+
+This library implements data transfer for the kubernetes_manifest interface. The library can be used by the requirer
+charm to send Kubernetes manifests to the provider charm. The manifests sent by the requirer using this charm lib is
+sent encapsulated inside a Juju secret that has been granted to the provider charm on the other side of the relation.
+
+## Getting Started
+
+To get started using the library, fetch the library with `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.resource_dispatcher.v0.kubernetes_manifests
+```
+
+In your charm, the library can be used in two ways depending on whether the manifests
+being sent by the charm are static (available when the charm starts up),
+or dynamic (for example a manifest template that gets rendered with data from a relation)
+
+If the manifests are static, instantiate the KubernetesManifestsRequirer.
+In your charm do:
+
+```python
+from charms.resource_dispatcher.v0.kubernetes_manifests import KubernetesManifestsRequirer, KubernetesManifest
+# ...
+
+SECRETS_MANIFESTS = [
+    KubernetesManifest(
+    Path(SECRET1_PATH).read_text()
+    ),
+    KubernetesManifest(
+    Path(SECRET2_PATH).read_text()
+    ),
+]
+
+SA_MANIFESTS = [
+    KubernetesManifest(
+    Path(SA1_PATH).read_text()
+    ),
+    KubernetesManifest(
+    Path(SA2_PATH).read_text()
+    ),
+]
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.secrets_manifests_requirer = KubernetesManifestsRequirer(
+            charm=self, relation_name="secrets", manifests_items=SECRETS_MANIFESTS
+        )
+    self.service_accounts_requirer = KubernetesManifestsRequirer(
+            charm=self, relation_name="service-accounts", manifests_items=SA_MANIFESTS
+        )
+    # ...
+```
+
+If the manifests are dynamic, instantiate the KubernetesManifestsRequirerWrapper.
+In your charm do:
+
+```python
+class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        # ...
+        self._secrets_manifests_wrapper = KubernetesManifestsRequirerWrapper(
+            charm = self,
+            relation_name = "secrets"
+        )
+        self._service_accounts_manifests_wrapper = KubernetesManifestsRequirerWrapper(
+            charm = self,
+            relation_name = "service-accounts"
+        )
+
+        self.framework.observe(self.on.leader_elected, self._send_secret)
+        self.framework.observe(self.on["secrets"].relation_created, self._send_secret)
+        # observe all the other events for when the secrets manifests change
+
+        self.framework.observe(self.on.leader_elected, self._send_service_account)
+        self.framework.observe(self.on["service-accounts"].relation_created, self._send_service_account)
+        # observe all the other events for when the service accounts manifests change
+
+    def _send_secret(self, _):
+        #...
+        Write the logic to re-calculate the manifests
+        rendered_manifests = ...
+        #...
+        manifest_items = [KubernetesManifest(rendered_manifests)]
+        self._secrets_manifests_wrapper.send_data(manifest_items)
+
+
+    def _send_service_account(self, _):
+        #...
+        Write the logic to re-calculate the manifests
+        rendered_manifests = ...
+        #...
+        manifest_items = [KubernetesManifest(rendered_manifests)]
+        self._service_accounts_manifests_wrapper.send_data(manifest_items)
+```
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional, Union
+
+import yaml
+from ops import ModelError, Relation, RelationChangedEvent, SecretRemoveEvent
+from ops.charm import CharmBase, RelationEvent, SecretChangedEvent
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.model import SecretNotFoundError
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "4254ac012d3640ccbe0ac5380b2436c8"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+KUBERNETES_MANIFESTS_FIELD = "kubernetes_manifests"
+IS_SECRET_FIELD = "is_secret"
+MANIFESTS_SECRET_KEY = "manifests"
+
+
+def generate_secret_label(relation: Relation) -> str:
+    """Generate a unique secret label based on the relation name and ID."""
+    return f"manifest.{relation.name}.{relation.id}"
+
+
+def parse_relation_id_from_secret_label(secret_label: str) -> Optional[int]:
+    """Parse the relation id from a secret label."""
+    pattern = r"^manifest\.(?P<relation_name>[^.]+)\.(?P<relation_id>\d+)$"
+    match = re.match(pattern, secret_label)
+    if not match:
+        return None
+    try:
+        return int(match.group("relation_id"))
+    except ValueError:
+        return None
+
+
+@dataclass
+class KubernetesManifest:
+    """
+    Representation of a Kubernetes Object sent to Kubernetes Manifests.
+
+    Args:
+        manifest_content: the content of the Kubernetes manifest file
+    """
+
+    manifest_content: str
+    manifest: dict = field(init=False)
+
+    def __post_init__(self):
+        """Validate that the manifest content is a valid YAML."""
+        self.manifest = yaml.safe_load(self.manifest_content)
+
+
+class KubernetesManifestsUpdatedEvent(RelationEvent):
+    """Indicates the Kubernetes Objects data was updated."""
+
+
+class KubernetesManifestsEvents(ObjectEvents):
+    """Events for the Kubernetes Manifests library."""
+
+    updated = EventSource(KubernetesManifestsUpdatedEvent)
+
+
+class KubernetesManifestsProvider(Object):
+    """Relation manager for the Provider side of the Kubernetes Manifests relations."""
+
+    on = KubernetesManifestsEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+    ):
+        """Relation manager for the Provider side of the Kubernetes Manifests relations.
+
+        This relation manager subscribes to:
+        * on[relation_name].relation_changed
+        * secret_changed
+        * any events provided in refresh_event
+
+        This library emits:
+        * KubernetesManifestsUpdatedEvent:
+            when data received on the relation (either as plaintext or as secret) is updated
+
+        Args:
+            charm: Charm this relation is being used by
+            relation_name: Name of this relation (from metadata.yaml)
+            refresh_event: List of BoundEvents that this manager should handle. Use this to update
+                           the data sent on this relation on demand.
+        """
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        self.framework.observe(self._charm.on.secret_changed, self._on_secret_changed_event)
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
+        )
+
+        # apply user defined events
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+
+            for evt in refresh_event:
+                self.framework.observe(evt, self._on_relation_changed)
+
+    def is_secret_enabled(self, relation: Relation) -> bool:
+        """Return whether secret support is enabled for this relation."""
+        return relation.data[relation.app].get(IS_SECRET_FIELD, "false") == "true"
+
+    def get_manifests(self) -> List[dict]:
+        """
+        Returns a list of manifest dictionaries sent in the data of relation relation_name.
+        If this relation supports sharing data over Juju secrets, the secret is decoded
+        on-the-fly to return the actual list of manifest dictionaries.
+        """
+
+        other_app_to_skip = get_name_of_breaking_app(relation_name=self._relation_name)
+
+        if other_app_to_skip:
+            logger.debug(
+                f"get_kubernetes_manifests executed during a relation-broken event.  Return will"
+                f"exclude {self._relation_name} manifests from other app named '{other_app_to_skip}'.  "
+            )
+
+        manifests = []
+
+        kubernetes_manifests_relations = self._charm.model.relations[self._relation_name]
+
+        for relation in kubernetes_manifests_relations:
+            other_app = relation.app
+            if other_app.name == other_app_to_skip:
+                # Skip this app because it is leaving a broken relation
+                continue
+
+            if self.is_secret_enabled(relation=relation):
+                secret_id = relation.data[other_app].get(KUBERNETES_MANIFESTS_FIELD, None)
+                if not secret_id:
+                    logger.error(
+                        f"Relation {relation.name} ID {relation.id} from app {other_app.name} indicates "
+                        f"manifests are in a secret, but no secret id was provided."
+                    )
+                    continue
+                try:
+                    secret = self._charm.model.get_secret(id=secret_id)
+                except SecretNotFoundError:
+                    logger.error(
+                        f"Relation {relation.name} ID {relation.id} from app {other_app.name} provided "
+                        f"secret id '{secret_id}' but no such secret exists."
+                    )
+                    raise
+                except ModelError:
+                    logger.error(
+                        f"Relation {relation.name} ID {relation.id} from app {other_app.name} provided "
+                        f"secret id '{secret_id}' but the secret cannot be read / decoded."
+                    )
+                    raise
+                secret_content = secret.get_content(refresh=True)
+                json_data = secret_content.get(MANIFESTS_SECRET_KEY, "[]")
+            else:
+                json_data = relation.data[other_app].get(KUBERNETES_MANIFESTS_FIELD, "[]")
+            manifests.extend(json.loads(json_data))
+
+        return manifests
+
+    def register_secrets_to_relation(self, relation: Relation):
+        """Register the secret received in the relation with a label (local to this application).
+        This is necessary because afterwards in secret-changed, we reference this secret with its local label.
+        """
+        if not self.is_secret_enabled(relation=relation):
+            logger.info(
+                f"Detected the other side of relation {relation.name} ID {relation.id} is not sending secret, "
+                "skipping secret registration."
+            )
+            return
+
+        secret_uri = relation.data[relation.app].get(KUBERNETES_MANIFESTS_FIELD)
+        if not secret_uri:
+            logger.error(
+                f"Could not find the secret URI in field {KUBERNETES_MANIFESTS_FIELD} in the relation data "
+                f"of the relation {relation.name} and ID {relation.id}."
+            )
+            return
+        secret_label = generate_secret_label(relation=relation)
+        try:
+            # Attach appropriate label to the secret
+            self.model.get_secret(id=secret_uri, label=secret_label)
+        except SecretNotFoundError:
+            logger.error(
+                f"The secret with URI {secret_uri} received in {relation.name} ID {relation.id} does not exist in the model."
+            )
+        except ModelError:
+            logger.error(
+                f"The secret with URI {secret_uri} received in {relation.name} ID {relation.id} could not be read / decoded."
+            )
+
+    def _on_relation_changed(self, event: RelationChangedEvent):
+        """Handler for relation-changed event for this relation."""
+        self.register_secrets_to_relation(event.relation)
+        self.on.updated.emit(event.relation)
+
+    def _on_relation_broken(self, event: BoundEvent):
+        """Handler for relation-broken event for this relation."""
+        self.on.updated.emit(event.relation)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event handler for handling a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        secret_label = event.secret.label
+        relation_id = parse_relation_id_from_secret_label(secret_label)
+        if relation_id is None:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't parse relation id, seems irrelevant."
+            )
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if not relation:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't fetch the relation, seems irrelevant."
+            )
+            return
+
+        if relation.app == self._charm.app:
+            logger.info("Secret changed event ignored for Secret Owner")
+            return
+
+        self.on.updated.emit(relation)
+
+
+class KubernetesManifestsRequirer(Object):
+    """Relation manager for the Requirer side of the Kubernetes Manifests relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        manifests_items: List[KubernetesManifest],
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+    ):
+        """
+        Relation manager for the Requirer side of the Kubernetes Manifests relation.
+
+        This relation manager subscribes to:
+        * on.leader_elected: because only the leader is allowed to provide this data, and
+                             relation_created may fire before the leadership election
+        * on[relation_name].relation_created
+
+        * any events provided in refresh_event
+
+        This library emits:
+        * (nothing)
+
+        Args:
+            charm: Charm this relation is being used by
+            relation_name: Name of this relation (from metadata.yaml)
+            manifests_items: List of KubernetesManifest objects to send over the relation
+            refresh_event: List of BoundEvents that this manager should handle.  Use this to update
+                           the data sent on this relation on demand.
+        """
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._manifests_items = manifests_items
+        self._requirer_wrapper = KubernetesManifestRequirerWrapper(
+            self._charm, self._relation_name
+        )
+
+        self.framework.observe(self._charm.on.leader_elected, self._send_data)
+
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_created, self._send_data
+        )
+        self.framework.observe(self._charm.on.secret_remove, self._on_secret_remove)
+
+        # apply user defined events
+        if refresh_event:
+            if not isinstance(refresh_event, (tuple, list)):
+                refresh_event = [refresh_event]
+
+            for evt in refresh_event:
+                self.framework.observe(evt, self._send_data)
+
+    def _send_data(self, event: EventBase):
+        """Handles any event where we should send data to the relation."""
+        self._requirer_wrapper.send_data(self._manifests_items)
+
+    def _on_secret_remove(self, event: SecretRemoveEvent):
+        """Handles secret-remove event, which gets triggered when secret revision is no longer being observed."""
+        if not event.secret.label:
+            return
+
+        relation_id = parse_relation_id_from_secret_label(event.secret.label)
+        if relation_id is None:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't parse relation id, seems irrelevant."
+            )
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if relation.name != self._relation_name:
+            logging.info("Event triggered for some other relation.")
+            return
+
+        # Ignore the event raised for secret that no longer exists
+        # https://github.com/juju/juju/issues/20794
+        try:
+            event.secret.get_info()
+        except SecretNotFoundError:
+            logging.info("Secret removed for non-existent secret.")
+            return
+
+        event.remove_revision()
+
+
+class KubernetesManifestRequirerWrapper(Object):
+    """
+    Wrapper for the relation data sending logic
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+    ):
+        self._charm = charm
+        self._relation_name = relation_name
+
+    def _get_manifests_from_items(self, manifests_items: List[KubernetesManifest]):
+        return [item.manifest for item in manifests_items]
+
+    def send_data(self, manifest_items: List[KubernetesManifest]):
+        """Sends the manifests data to the relation in json format."""
+        if not self._charm.model.unit.is_leader():
+            logger.info(
+                "KubernetesManifestsRequirer handled send_data event when it is not the "
+                "leader.  Skipping event - no data sent."
+            )
+            return
+
+        manifests = self._get_manifests_from_items(manifest_items)
+        relations = self._charm.model.relations.get(self._relation_name)
+
+        for relation in relations:
+            relation_data = relation.data[self._charm.app]
+            manifests_as_json = json.dumps(manifests)
+            secret_content = {MANIFESTS_SECRET_KEY: manifests_as_json}
+            secret_label = generate_secret_label(relation=relation)
+            try:
+                secret = self._charm.model.get_secret(label=secret_label)
+                secret.set_content(secret_content)
+            except SecretNotFoundError:
+                secret = self._charm.app.add_secret(content=secret_content, label=secret_label)
+            except ModelError:
+                logger.error(
+                    f"The secret with label {secret_label} could not be accessed by the charm."
+                )
+                raise
+            secret.grant(relation=relation)
+            relation_data.update({KUBERNETES_MANIFESTS_FIELD: secret.id, IS_SECRET_FIELD: "true"})
+
+
+def get_name_of_breaking_app(relation_name: str) -> Optional[str]:
+    """
+    Get the name of a remote application that is leaving the relation during a relation broken event by
+    checking Juju environment variables.
+    If the application name is available, returns the name as a string;
+    otherwise None.
+    """
+    # In the case of a relation-broken event, Juju non-deterministically may or may not include
+    # the breaking remote app's data in the relation data bag.  If this data is still in the data
+    # bag, the `JUJU_REMOTE_APP` name will always be set.  For these cases, we return the
+    # remote app name so the caller can remove that app from the data bag before using it.
+    #
+    # To catch these cases, we inspect the following environment variables managed by Juju:
+    #   JUJU_REMOTE_APP: the name of the app we are interacting with on this relation event
+    #   JUJU_RELATION: the name of the relation we are interacting with on this relation event
+    #   JUJU_HOOK_NAME: the name of the relation event, such as RELATION_NAME-relation-broken
+    # See https://juju.is/docs/sdk/charm-environment-variables for more detail on these variables.
+    if not os.environ.get("JUJU_REMOTE_APP", None):
+        # No remote app is defined
+        return None
+    if not os.environ.get("JUJU_RELATION", None) == relation_name:
+        # Not this relation
+        return None
+    if not os.environ.get("JUJU_HOOK_NAME", None) == f"{relation_name}-relation-broken":
+        # Not the relation-broken event
+        return None
+
+    return os.environ.get("JUJU_REMOTE_APP", None)

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -63,4 +63,12 @@ requires:
     interface: service_mesh
   require-cmr-mesh:
     interface: cross_model_mesh
+  secrets:
+    interface: kubernetes_manifest
+    optional: true
+    limit: 1
+  configmaps:
+    interface: kubernetes_manifest
+    optional: true
+    limit: 1
 charm-user: non-root

--- a/charms/kfp-profile-controller/metadata.yaml
+++ b/charms/kfp-profile-controller/metadata.yaml
@@ -63,11 +63,11 @@ requires:
     interface: service_mesh
   require-cmr-mesh:
     interface: cross_model_mesh
-  secrets:
+  config-maps:
     interface: kubernetes_manifest
     optional: true
     limit: 1
-  configmaps:
+  secrets:
     interface: kubernetes_manifest
     optional: true
     limit: 1

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -67,10 +67,10 @@ METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
 
-# resource-dispatcher (kubernetes_manifest) relation endpoints. When related, the
+# Endpoints for integration with resource-dispatcher. When related, the
 # corresponding resource is created by resource-dispatcher instead of by sync.py.
 SECRETS_RELATION_NAME = "secrets"
-CONFIGMAPS_RELATION_NAME = "configmaps"
+CONFIGMAPS_RELATION_NAME = "config-maps"
 
 HOOKS_PATH = Path("/var/lib/pebble/default")
 

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -40,6 +40,7 @@ from components.pebble_components import (
     KfpProfileControllerInputs,
     KfpProfileControllerPebbleService,
 )
+from components.resource_dispatcher_manifests import ResourceDispatcherManifestsComponent
 from components.service_mesh_component import ServiceMeshComponent
 
 DEFAULT_IMAGES_FILE = "src/default-custom-images.json"
@@ -65,6 +66,11 @@ KFP_IMAGES_VERSION = "2.16.0"  # Remember to change this version also in default
 METADATA_GRPC_SERVICE_PORT = "8080"
 NAMESPACE_LABEL = "pipelines.kubeflow.org/enabled"
 SYNC_CODE_FILE = Path("files/upstream/sync.py")
+
+# resource-dispatcher (kubernetes_manifest) relation endpoints. When related, the
+# corresponding resource is created by resource-dispatcher instead of by sync.py.
+SECRETS_RELATION_NAME = "secrets"
+CONFIGMAPS_RELATION_NAME = "configmaps"
 
 HOOKS_PATH = Path("/var/lib/pebble/default")
 
@@ -191,6 +197,24 @@ class KfpProfileControllerOperator(CharmBase):
             depends_on=[self.leadership_gate],
         )
 
+        self.resource_dispatcher_manifests = self.charm_reconciler.add(
+            component=ResourceDispatcherManifestsComponent(
+                charm=self,
+                name="resource-dispatcher-manifests",
+                object_storage_validator=self.object_storage_validator.component,
+                default_pipeline_root=self.default_pipeline_root,
+                secrets_relation_name=SECRETS_RELATION_NAME,
+                configmaps_relation_name=CONFIGMAPS_RELATION_NAME,
+            ),
+            depends_on=[
+                self.leadership_gate,
+                self.s3_relations_conflict_detector,
+                self.s3_relation,
+                self.object_storage_relation,
+                self.object_storage_validator,
+            ],
+        )
+
         self.kubernetes_resources = self.charm_reconciler.add(
             component=KubernetesComponent(
                 charm=self,
@@ -282,6 +306,14 @@ class KfpProfileControllerOperator(CharmBase):
             KFP_API_PRINCIPAL=self._get_kfp_api_principal(),
             AMBIENT_ENABLED=self.service_mesh_component.component.ambient_mesh_enabled,
             HOOKS_PATH=HOOKS_PATH,
+            # If the corresponding resource-dispatcher relation exists, the resource is created
+            # by resource-dispatcher, so sync.py should not manage (create) it.
+            MANAGE_MINIO_SECRET=str(
+                self.model.get_relation(SECRETS_RELATION_NAME) is None
+            ).lower(),
+            MANAGE_KFP_LAUNCHER_CONFIGMAP=str(
+                self.model.get_relation(CONFIGMAPS_RELATION_NAME) is None
+            ).lower(),
         )
 
     def _get_kfp_api_principal(self) -> str:

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -10,7 +10,6 @@ https://github.com/canonical/kfp-operators
 import json
 import logging
 from base64 import b64encode
-from functools import partial
 from pathlib import Path
 from typing import Dict
 
@@ -41,11 +40,7 @@ from components.pebble_components import (
     KfpProfileControllerInputs,
     KfpProfileControllerPebbleService,
 )
-from components.resource_dispatcher_manifests import (
-    ResourceDispatcherManifestsComponent,
-    kfp_launcher_configmap_manifest,
-    minio_secret_manifest,
-)
+from components.resource_dispatcher_manifests import ResourceDispatcherManifestsComponent
 from components.service_mesh_component import ServiceMeshComponent
 
 DEFAULT_IMAGES_FILE = "src/default-custom-images.json"
@@ -76,6 +71,10 @@ SYNC_CODE_FILE = Path("files/upstream/sync.py")
 # corresponding resource is created by resource-dispatcher instead of by sync.py.
 SECRETS_RELATION_NAME = "secrets"
 CONFIGMAPS_RELATION_NAME = "config-maps"
+
+# Templates defining the manifests sent to resource-dispatcher
+MINIO_SECRET_TEMPLATE = "src/templates/minio_secret.yaml.j2"
+KFP_LAUNCHER_CONFIGMAP_TEMPLATE = "src/templates/kfp_launcher_configmap.yaml.j2"
 
 HOOKS_PATH = Path("/var/lib/pebble/default")
 
@@ -214,8 +213,9 @@ class KfpProfileControllerOperator(CharmBase):
                 charm=self,
                 name="resource-dispatcher-secrets",
                 object_storage_validator=self.object_storage_validator.component,
+                default_pipeline_root=self.default_pipeline_root,
                 relation_name=SECRETS_RELATION_NAME,
-                manifest_builder=minio_secret_manifest,
+                template_path=MINIO_SECRET_TEMPLATE,
             ),
             depends_on=resource_dispatcher_depends_on,
         )
@@ -224,11 +224,9 @@ class KfpProfileControllerOperator(CharmBase):
                 charm=self,
                 name="resource-dispatcher-configmaps",
                 object_storage_validator=self.object_storage_validator.component,
+                default_pipeline_root=self.default_pipeline_root,
                 relation_name=CONFIGMAPS_RELATION_NAME,
-                manifest_builder=partial(
-                    kfp_launcher_configmap_manifest,
-                    default_pipeline_root=self.default_pipeline_root,
-                ),
+                template_path=KFP_LAUNCHER_CONFIGMAP_TEMPLATE,
             ),
             depends_on=resource_dispatcher_depends_on,
         )

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -10,6 +10,7 @@ https://github.com/canonical/kfp-operators
 import json
 import logging
 from base64 import b64encode
+from functools import partial
 from pathlib import Path
 from typing import Dict
 
@@ -40,7 +41,11 @@ from components.pebble_components import (
     KfpProfileControllerInputs,
     KfpProfileControllerPebbleService,
 )
-from components.resource_dispatcher_manifests import ResourceDispatcherManifestsComponent
+from components.resource_dispatcher_manifests import (
+    ResourceDispatcherManifestsComponent,
+    kfp_launcher_configmap_manifest,
+    minio_secret_manifest,
+)
 from components.service_mesh_component import ServiceMeshComponent
 
 DEFAULT_IMAGES_FILE = "src/default-custom-images.json"
@@ -197,22 +202,35 @@ class KfpProfileControllerOperator(CharmBase):
             depends_on=[self.leadership_gate],
         )
 
-        self.resource_dispatcher_manifests = self.charm_reconciler.add(
+        resource_dispatcher_depends_on = [
+            self.leadership_gate,
+            self.s3_relations_conflict_detector,
+            self.s3_relation,
+            self.object_storage_relation,
+            self.object_storage_validator,
+        ]
+        self.resource_dispatcher_secrets = self.charm_reconciler.add(
             component=ResourceDispatcherManifestsComponent(
                 charm=self,
-                name="resource-dispatcher-manifests",
+                name="resource-dispatcher-secrets",
                 object_storage_validator=self.object_storage_validator.component,
-                default_pipeline_root=self.default_pipeline_root,
-                secrets_relation_name=SECRETS_RELATION_NAME,
-                configmaps_relation_name=CONFIGMAPS_RELATION_NAME,
+                relation_name=SECRETS_RELATION_NAME,
+                manifest_builder=minio_secret_manifest,
             ),
-            depends_on=[
-                self.leadership_gate,
-                self.s3_relations_conflict_detector,
-                self.s3_relation,
-                self.object_storage_relation,
-                self.object_storage_validator,
-            ],
+            depends_on=resource_dispatcher_depends_on,
+        )
+        self.resource_dispatcher_configmaps = self.charm_reconciler.add(
+            component=ResourceDispatcherManifestsComponent(
+                charm=self,
+                name="resource-dispatcher-configmaps",
+                object_storage_validator=self.object_storage_validator.component,
+                relation_name=CONFIGMAPS_RELATION_NAME,
+                manifest_builder=partial(
+                    kfp_launcher_configmap_manifest,
+                    default_pipeline_root=self.default_pipeline_root,
+                ),
+            ),
+            depends_on=resource_dispatcher_depends_on,
         )
 
         self.kubernetes_resources = self.charm_reconciler.add(

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -92,6 +92,8 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                             "KFP_API_PRINCIPAL": inputs.KFP_API_PRINCIPAL,
                             # These inputs determine whether the resources should be
                             # created by sync.py or by resource-dispatcher.
+                            # MANAGE_MINIO_SECRET -> `mlpipieline-minio-artifact` Secret
+                            # MANAGE_KFP_LAUNCHER_CONFIMAP -> `kfp-launcher` ConfigMap
                             "MANAGE_MINIO_SECRET": inputs.MANAGE_MINIO_SECRET,
                             "MANAGE_KFP_LAUNCHER_CONFIGMAP": inputs.MANAGE_KFP_LAUNCHER_CONFIGMAP,
                         },

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -34,6 +34,8 @@ class KfpProfileControllerInputs:
     KFP_API_PRINCIPAL: str
     AMBIENT_ENABLED: str
     HOOKS_PATH: Path
+    MANAGE_MINIO_SECRET: str
+    MANAGE_KFP_LAUNCHER_CONFIGMAP: str
 
 
 class KfpProfileControllerPebbleService(PebbleServiceComponent):
@@ -88,6 +90,11 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                             "FRONTEND_TAG": inputs.FRONTEND_TAG,
                             "AMBIENT_ENABLED": inputs.AMBIENT_ENABLED,
                             "KFP_API_PRINCIPAL": inputs.KFP_API_PRINCIPAL,
+                            # When integrated with resource-dispatcher over the secrets /
+                            # configmaps relations, the corresponding resources are created by
+                            # resource-dispatcher, so sync.py must not create them.
+                            "MANAGE_MINIO_SECRET": inputs.MANAGE_MINIO_SECRET,
+                            "MANAGE_KFP_LAUNCHER_CONFIGMAP": inputs.MANAGE_KFP_LAUNCHER_CONFIGMAP,
                         },
                     }
                 }

--- a/charms/kfp-profile-controller/src/components/pebble_components.py
+++ b/charms/kfp-profile-controller/src/components/pebble_components.py
@@ -90,9 +90,8 @@ class KfpProfileControllerPebbleService(PebbleServiceComponent):
                             "FRONTEND_TAG": inputs.FRONTEND_TAG,
                             "AMBIENT_ENABLED": inputs.AMBIENT_ENABLED,
                             "KFP_API_PRINCIPAL": inputs.KFP_API_PRINCIPAL,
-                            # When integrated with resource-dispatcher over the secrets /
-                            # configmaps relations, the corresponding resources are created by
-                            # resource-dispatcher, so sync.py must not create them.
+                            # These inputs determine whether the resources should be
+                            # created by sync.py or by resource-dispatcher.
                             "MANAGE_MINIO_SECRET": inputs.MANAGE_MINIO_SECRET,
                             "MANAGE_KFP_LAUNCHER_CONFIGMAP": inputs.MANAGE_KFP_LAUNCHER_CONFIGMAP,
                         },

--- a/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
+++ b/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
@@ -9,22 +9,19 @@ The two relations are independent, so each is handled by its own instance of
 `ResourceDispatcherManifestsComponent`:
   * `secrets`     -> the `mlpipeline-minio-artifact` Secret
   * `config-maps` -> the `kfp-launcher` ConfigMap
-
-Manifests are sent without a `metadata.namespace` so that `resource-dispatcher` treats
-them as global manifests and applies them to every Profile namespace.
 """
 
 import logging
 from base64 import b64encode
-from typing import Callable
+from pathlib import Path
 
-import yaml
 from charmed_kubeflow_chisme.components import Component
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charms.resource_dispatcher.v0.kubernetes_manifests import (
     KubernetesManifest,
     KubernetesManifestRequirerWrapper,
 )
+from jinja2 import Template
 from ops import ActiveStatus, CharmBase, StatusBase
 
 from components.object_storage_validator import ObjectStorageValidatorComponent
@@ -33,57 +30,6 @@ logger = logging.getLogger(__name__)
 
 MINIO_SECRET_NAME = "mlpipeline-minio-artifact"
 KFP_LAUNCHER_CONFIGMAP_NAME = "kfp-launcher"
-
-
-def minio_secret_manifest(object_storage: dict) -> str:
-    """Return the mlpipeline-minio-artifact Secret manifest (without a namespace)."""
-    manifest = {
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "metadata": {
-            "name": MINIO_SECRET_NAME,
-        },
-        "data": {
-            "accesskey": b64encode(object_storage["access_key"].encode("utf-8")).decode("utf-8"),
-            "secretkey": b64encode(object_storage["secret_key"].encode("utf-8")).decode("utf-8"),
-        },
-    }
-    return yaml.safe_dump(manifest)
-
-
-def kfp_launcher_configmap_manifest(object_storage: dict, default_pipeline_root: str) -> str:
-    """Return the kfp-launcher ConfigMap manifest (without a namespace).
-
-    This mirrors the `providers` configuration built in `files/upstream/sync.py` so
-    that resource-dispatcher creates the same ConfigMap it would otherwise create.
-    """
-    providers_yaml = (
-        "minio:\n"
-        "  default:\n"
-        f"    endpoint: {object_storage['endpoint']}\n"
-        f"    disableSSL: {'false' if object_storage['secure'] else 'true'}\n"
-        f"    region: {object_storage['region']}\n"
-        "    forcePathStyle: true\n"
-        "    credentials:\n"
-        "      fromEnv: false\n"
-        "      secretRef:\n"
-        f"        secretName: {MINIO_SECRET_NAME}\n"
-        "        accessKeyKey: accesskey\n"
-        "        secretKeyKey: secretkey"
-    )
-    configmap_data = {"providers": providers_yaml}
-    if default_pipeline_root:
-        configmap_data["defaultPipelineRoot"] = default_pipeline_root
-
-    manifest = {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {
-            "name": KFP_LAUNCHER_CONFIGMAP_NAME,
-        },
-        "data": configmap_data,
-    }
-    return yaml.safe_dump(manifest)
 
 
 class ResourceDispatcherManifestsComponent(Component):
@@ -99,8 +45,9 @@ class ResourceDispatcherManifestsComponent(Component):
         charm: CharmBase,
         name: str,
         object_storage_validator: ObjectStorageValidatorComponent,
+        default_pipeline_root: str,
         relation_name: str,
-        manifest_builder: Callable[[dict], str],
+        template_path: str,
     ):
         """Initialise the component.
 
@@ -108,14 +55,16 @@ class ResourceDispatcherManifestsComponent(Component):
             charm: the parent charm.
             name: unique component name.
             object_storage_validator: component providing the normalized object storage data.
+            default_pipeline_root: the `default_pipeline_root` config value.
             relation_name: name of the resource-dispatcher endpoint this component handles.
-            manifest_builder: callable rendering the manifest from the object storage data.
+            template_path: path to the Jinja template defining the manifest to send.
         """
         super().__init__(charm=charm, name=name)
         self._charm = charm
         self._object_storage_validator = object_storage_validator
+        self._default_pipeline_root = default_pipeline_root
         self._relation_name = relation_name
-        self._manifest_builder = manifest_builder
+        self._template_path = template_path
         self._wrapper = KubernetesManifestRequirerWrapper(
             charm=self._charm, relation_name=self._relation_name
         )
@@ -133,6 +82,29 @@ class ResourceDispatcherManifestsComponent(Component):
         """Return whether the relation is established."""
         return self._charm.model.get_relation(self._relation_name) is not None
 
+    def _render_manifest(self, object_storage: dict) -> str:
+        """Render the manifest template with the object storage data.
+
+        A single render context is shared across templates; each template uses only the
+        values it needs.
+        """
+        context = {
+            "minio_secret_name": MINIO_SECRET_NAME,
+            "kfp_launcher_configmap_name": KFP_LAUNCHER_CONFIGMAP_NAME,
+            "access_key_b64": b64encode(object_storage["access_key"].encode("utf-8")).decode(
+                "utf-8"
+            ),
+            "secret_key_b64": b64encode(object_storage["secret_key"].encode("utf-8")).decode(
+                "utf-8"
+            ),
+            "endpoint": object_storage["endpoint"],
+            "secure": object_storage["secure"],
+            "region": object_storage["region"],
+            "default_pipeline_root": self._default_pipeline_root,
+        }
+        template = Template(Path(self._template_path).read_text())
+        return template.render(**context)
+
     def _configure_app_leader(self, event):
         """Render and send the manifest to resource-dispatcher when the relation is present."""
         if not self._is_related():
@@ -140,7 +112,7 @@ class ResourceDispatcherManifestsComponent(Component):
             return
 
         object_storage = self._object_storage_validator.get_normalized_data()
-        self._wrapper.send_data([KubernetesManifest(self._manifest_builder(object_storage))])
+        self._wrapper.send_data([KubernetesManifest(self._render_manifest(object_storage))])
 
     def get_status(self) -> StatusBase:
         """Return the component status.

--- a/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
+++ b/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
@@ -1,0 +1,177 @@
+"""Chisme component that sends resources to resource-dispatcher for multi-tenancy.
+
+When ``kfp-profile-controller`` is integrated with ``resource-dispatcher`` over the
+``secrets`` and/or ``configmaps`` (``kubernetes_manifest``) relations, the resources that
+are otherwise created per user-namespace by ``files/upstream/sync.py`` are instead sent to
+``resource-dispatcher`` so that it can create (and compose) them in every Profile namespace.
+
+The two relations are independent:
+  * ``secrets``    -> the ``mlpipeline-minio-artifact`` Secret
+  * ``configmaps`` -> the ``kfp-launcher`` ConfigMap
+
+Manifests are sent without a ``metadata.namespace`` so that ``resource-dispatcher`` treats
+them as global manifests and applies them to every Profile namespace.
+"""
+
+import logging
+from base64 import b64encode
+
+import yaml
+from charmed_kubeflow_chisme.components import Component
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charms.resource_dispatcher.v0.kubernetes_manifests import (
+    KubernetesManifest,
+    KubernetesManifestRequirerWrapper,
+)
+from ops import ActiveStatus, CharmBase, StatusBase
+
+from components.object_storage_validator import ObjectStorageValidatorComponent
+
+logger = logging.getLogger(__name__)
+
+MINIO_SECRET_NAME = "mlpipeline-minio-artifact"
+KFP_LAUNCHER_CONFIGMAP_NAME = "kfp-launcher"
+
+
+class ResourceDispatcherManifestsComponent(Component):
+    """Sends the minio Secret and kfp-launcher ConfigMap to resource-dispatcher.
+
+    This component renders and sends the manifests only for the relations that are present,
+    keeping the ``secrets`` and ``configmaps`` integrations independent. When neither relation
+    exists, the component is a no-op (the resources are created by ``sync.py`` instead).
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        name: str,
+        object_storage_validator: ObjectStorageValidatorComponent,
+        default_pipeline_root: str,
+        secrets_relation_name: str = "secrets",
+        configmaps_relation_name: str = "configmaps",
+    ):
+        """Initialise the component.
+
+        Args:
+            charm: the parent charm.
+            name: unique component name.
+            object_storage_validator: component providing the normalized object storage data.
+            default_pipeline_root: the ``default_pipeline_root`` config value.
+            secrets_relation_name: name of the secrets endpoint. Defaults to "secrets".
+            configmaps_relation_name: name of the configmaps endpoint. Defaults to "configmaps".
+        """
+        super().__init__(charm=charm, name=name)
+        self._charm = charm
+        self._object_storage_validator = object_storage_validator
+        self._default_pipeline_root = default_pipeline_root
+        self._secrets_relation_name = secrets_relation_name
+        self._configmaps_relation_name = configmaps_relation_name
+        self._secrets_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self._charm, relation_name=self._secrets_relation_name
+        )
+        self._configmaps_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self._charm, relation_name=self._configmaps_relation_name
+        )
+        # Reconcile (and thus (re)send manifests) whenever either resource-dispatcher relation
+        # changes, so the resources are (re)sent as soon as the relation is established.
+        for relation_name in (self._secrets_relation_name, self._configmaps_relation_name):
+            self._events_to_observe.extend(
+                [
+                    self._charm.on[relation_name].relation_created,
+                    self._charm.on[relation_name].relation_changed,
+                    self._charm.on[relation_name].relation_broken,
+                ]
+            )
+
+    def _is_related(self, relation_name: str) -> bool:
+        """Return whether the given relation is established."""
+        return self._charm.model.get_relation(relation_name) is not None
+
+    def _minio_secret_manifest(self, object_storage: dict) -> str:
+        """Return the mlpipeline-minio-artifact Secret manifest (without a namespace)."""
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": MINIO_SECRET_NAME,
+            },
+            "data": {
+                "accesskey": b64encode(object_storage["access_key"].encode("utf-8")).decode(
+                    "utf-8"
+                ),
+                "secretkey": b64encode(object_storage["secret_key"].encode("utf-8")).decode(
+                    "utf-8"
+                ),
+            },
+        }
+        return yaml.safe_dump(manifest)
+
+    def _kfp_launcher_configmap_manifest(self, object_storage: dict) -> str:
+        """Return the kfp-launcher ConfigMap manifest (without a namespace).
+
+        This mirrors the ``providers`` configuration built in ``files/upstream/sync.py`` so
+        that resource-dispatcher creates the same ConfigMap it would otherwise create.
+        """
+        providers_yaml = (
+            "minio:\n"
+            "  default:\n"
+            f"    endpoint: {object_storage['endpoint']}\n"
+            f"    disableSSL: {'false' if object_storage['secure'] else 'true'}\n"
+            f"    region: {object_storage['region']}\n"
+            "    forcePathStyle: true\n"
+            "    credentials:\n"
+            "      fromEnv: false\n"
+            "      secretRef:\n"
+            f"        secretName: {MINIO_SECRET_NAME}\n"
+            "        accessKeyKey: accesskey\n"
+            "        secretKeyKey: secretkey"
+        )
+        configmap_data = {"providers": providers_yaml}
+        if self._default_pipeline_root:
+            configmap_data["defaultPipelineRoot"] = self._default_pipeline_root
+
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": KFP_LAUNCHER_CONFIGMAP_NAME,
+            },
+            "data": configmap_data,
+        }
+        return yaml.safe_dump(manifest)
+
+    def _configure_app_leader(self, event):
+        """Render and send manifests to resource-dispatcher for the related endpoints."""
+        secrets_related = self._is_related(self._secrets_relation_name)
+        configmaps_related = self._is_related(self._configmaps_relation_name)
+
+        if not secrets_related and not configmaps_related:
+            # Not integrated with resource-dispatcher; sync.py creates the resources instead.
+            return
+
+        object_storage = self._object_storage_validator.get_normalized_data()
+
+        if secrets_related:
+            self._secrets_wrapper.send_data(
+                [KubernetesManifest(self._minio_secret_manifest(object_storage))]
+            )
+        if configmaps_related:
+            self._configmaps_wrapper.send_data(
+                [KubernetesManifest(self._kfp_launcher_configmap_manifest(object_storage))]
+            )
+
+    def get_status(self) -> StatusBase:
+        """Return the component status.
+
+        The component is Active unless the (already validated) object storage data cannot be
+        read while a resource-dispatcher relation is present.
+        """
+        if not self._is_related(self._secrets_relation_name) and not self._is_related(
+            self._configmaps_relation_name
+        ):
+            return ActiveStatus()
+        try:
+            self._object_storage_validator.get_normalized_data()
+        except ErrorWithStatus as err:
+            return err.status
+        return ActiveStatus()

--- a/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
+++ b/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
@@ -7,7 +7,7 @@ so that it can create them in every Profile namespace.
 
 The two relations are independent:
   * `secrets`    -> the `mlpipeline-minio-artifact` Secret
-  * `config-maps`` -> handles the `kfp-launcher` ConfigMap
+  * `config-maps` -> handles the `kfp-launcher` ConfigMap
 
 Manifests are sent without a `metadata.namespace` so that `resource-dispatcher` treats
 them as global manifests and applies them to every Profile namespace.

--- a/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
+++ b/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
@@ -1,13 +1,14 @@
-"""Chisme component that sends resources to resource-dispatcher for multi-tenancy.
+"""Chisme component that sends a resource to resource-dispatcher for multi-tenancy.
 
 When `kfp-profile-controller` is integrated with `resource-dispatcher` over the
 `secrets` and `config-maps` relations, the resources that are otherwise created per
 user-namespace by `files/upstream/sync.py` are instead sent to `resource-dispatcher`
 so that it can create them in every Profile namespace.
 
-The two relations are independent:
-  * `secrets`    -> the `mlpipeline-minio-artifact` Secret
-  * `config-maps` -> handles the `kfp-launcher` ConfigMap
+The two relations are independent, so each is handled by its own instance of
+`ResourceDispatcherManifestsComponent`:
+  * `secrets`     -> the `mlpipeline-minio-artifact` Secret
+  * `config-maps` -> the `kfp-launcher` ConfigMap
 
 Manifests are sent without a `metadata.namespace` so that `resource-dispatcher` treats
 them as global manifests and applies them to every Profile namespace.
@@ -15,6 +16,7 @@ them as global manifests and applies them to every Profile namespace.
 
 import logging
 from base64 import b64encode
+from typing import Callable
 
 import yaml
 from charmed_kubeflow_chisme.components import Component
@@ -33,11 +35,63 @@ MINIO_SECRET_NAME = "mlpipeline-minio-artifact"
 KFP_LAUNCHER_CONFIGMAP_NAME = "kfp-launcher"
 
 
-class ResourceDispatcherManifestsComponent(Component):
-    """Sends the minio Secret and kfp-launcher ConfigMap to resource-dispatcher.
+def minio_secret_manifest(object_storage: dict) -> str:
+    """Return the mlpipeline-minio-artifact Secret manifest (without a namespace)."""
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": MINIO_SECRET_NAME,
+        },
+        "data": {
+            "accesskey": b64encode(object_storage["access_key"].encode("utf-8")).decode("utf-8"),
+            "secretkey": b64encode(object_storage["secret_key"].encode("utf-8")).decode("utf-8"),
+        },
+    }
+    return yaml.safe_dump(manifest)
 
-    This component renders and sends the manifests only for the relations that are present,
-    keeping the `secrets` and `configmaps` integrations independent.
+
+def kfp_launcher_configmap_manifest(object_storage: dict, default_pipeline_root: str) -> str:
+    """Return the kfp-launcher ConfigMap manifest (without a namespace).
+
+    This mirrors the `providers` configuration built in `files/upstream/sync.py` so
+    that resource-dispatcher creates the same ConfigMap it would otherwise create.
+    """
+    providers_yaml = (
+        "minio:\n"
+        "  default:\n"
+        f"    endpoint: {object_storage['endpoint']}\n"
+        f"    disableSSL: {'false' if object_storage['secure'] else 'true'}\n"
+        f"    region: {object_storage['region']}\n"
+        "    forcePathStyle: true\n"
+        "    credentials:\n"
+        "      fromEnv: false\n"
+        "      secretRef:\n"
+        f"        secretName: {MINIO_SECRET_NAME}\n"
+        "        accessKeyKey: accesskey\n"
+        "        secretKeyKey: secretkey"
+    )
+    configmap_data = {"providers": providers_yaml}
+    if default_pipeline_root:
+        configmap_data["defaultPipelineRoot"] = default_pipeline_root
+
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": KFP_LAUNCHER_CONFIGMAP_NAME,
+        },
+        "data": configmap_data,
+    }
+    return yaml.safe_dump(manifest)
+
+
+class ResourceDispatcherManifestsComponent(Component):
+    """Sends a single manifest to resource-dispatcher over one relation.
+
+    Each instance handles exactly one resource-dispatcher relation, rendering and sending
+    its manifest only when that relation is present. Instantiate one component per relation
+    (e.g. one for `secrets` and one for `config-maps`) to keep the integrations independent.
     """
 
     def __init__(
@@ -45,9 +99,8 @@ class ResourceDispatcherManifestsComponent(Component):
         charm: CharmBase,
         name: str,
         object_storage_validator: ObjectStorageValidatorComponent,
-        default_pipeline_root: str,
-        secrets_relation_name: str = "secrets",
-        configmaps_relation_name: str = "config-maps",
+        relation_name: str,
+        manifest_builder: Callable[[dict], str],
     ):
         """Initialise the component.
 
@@ -55,119 +108,47 @@ class ResourceDispatcherManifestsComponent(Component):
             charm: the parent charm.
             name: unique component name.
             object_storage_validator: component providing the normalized object storage data.
-            default_pipeline_root: the `default_pipeline_root` config value.
-            secrets_relation_name: name of the secrets endpoint.
-            configmaps_relation_name: name of the configmaps endpoint.
+            relation_name: name of the resource-dispatcher endpoint this component handles.
+            manifest_builder: callable rendering the manifest from the object storage data.
         """
         super().__init__(charm=charm, name=name)
         self._charm = charm
         self._object_storage_validator = object_storage_validator
-        self._default_pipeline_root = default_pipeline_root
-        self._secrets_relation_name = secrets_relation_name
-        self._configmaps_relation_name = configmaps_relation_name
-        self._secrets_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self._charm, relation_name=self._secrets_relation_name
+        self._relation_name = relation_name
+        self._manifest_builder = manifest_builder
+        self._wrapper = KubernetesManifestRequirerWrapper(
+            charm=self._charm, relation_name=self._relation_name
         )
-        self._configmaps_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self._charm, relation_name=self._configmaps_relation_name
+        # Reconcile (and thus (re)send the manifest) whenever the resource-dispatcher relation
+        # changes, so the resource is (re)sent as soon as the relation is established.
+        self._events_to_observe.extend(
+            [
+                self._charm.on[self._relation_name].relation_created,
+                self._charm.on[self._relation_name].relation_changed,
+                self._charm.on[self._relation_name].relation_broken,
+            ]
         )
-        # Reconcile (and thus (re)send manifests) whenever either resource-dispatcher relation
-        # changes, so the resources are (re)sent as soon as the relation is established.
-        for relation_name in (self._secrets_relation_name, self._configmaps_relation_name):
-            self._events_to_observe.extend(
-                [
-                    self._charm.on[relation_name].relation_created,
-                    self._charm.on[relation_name].relation_changed,
-                    self._charm.on[relation_name].relation_broken,
-                ]
-            )
 
-    def _is_related(self, relation_name: str) -> bool:
-        """Return whether the given relation is established."""
-        return self._charm.model.get_relation(relation_name) is not None
-
-    def _minio_secret_manifest(self, object_storage: dict) -> str:
-        """Return the mlpipeline-minio-artifact Secret manifest (without a namespace)."""
-        manifest = {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "metadata": {
-                "name": MINIO_SECRET_NAME,
-            },
-            "data": {
-                "accesskey": b64encode(object_storage["access_key"].encode("utf-8")).decode(
-                    "utf-8"
-                ),
-                "secretkey": b64encode(object_storage["secret_key"].encode("utf-8")).decode(
-                    "utf-8"
-                ),
-            },
-        }
-        return yaml.safe_dump(manifest)
-
-    def _kfp_launcher_configmap_manifest(self, object_storage: dict) -> str:
-        """Return the kfp-launcher ConfigMap manifest (without a namespace).
-
-        This mirrors the `providers` configuration built in `files/upstream/sync.py` so
-        that resource-dispatcher creates the same ConfigMap it would otherwise create.
-        """
-        providers_yaml = (
-            "minio:\n"
-            "  default:\n"
-            f"    endpoint: {object_storage['endpoint']}\n"
-            f"    disableSSL: {'false' if object_storage['secure'] else 'true'}\n"
-            f"    region: {object_storage['region']}\n"
-            "    forcePathStyle: true\n"
-            "    credentials:\n"
-            "      fromEnv: false\n"
-            "      secretRef:\n"
-            f"        secretName: {MINIO_SECRET_NAME}\n"
-            "        accessKeyKey: accesskey\n"
-            "        secretKeyKey: secretkey"
-        )
-        configmap_data = {"providers": providers_yaml}
-        if self._default_pipeline_root:
-            configmap_data["defaultPipelineRoot"] = self._default_pipeline_root
-
-        manifest = {
-            "apiVersion": "v1",
-            "kind": "ConfigMap",
-            "metadata": {
-                "name": KFP_LAUNCHER_CONFIGMAP_NAME,
-            },
-            "data": configmap_data,
-        }
-        return yaml.safe_dump(manifest)
+    def _is_related(self) -> bool:
+        """Return whether the relation is established."""
+        return self._charm.model.get_relation(self._relation_name) is not None
 
     def _configure_app_leader(self, event):
-        """Render and send manifests to resource-dispatcher for the related endpoints."""
-        secrets_related = self._is_related(self._secrets_relation_name)
-        configmaps_related = self._is_related(self._configmaps_relation_name)
-
-        if not secrets_related and not configmaps_related:
-            # Not integrated with resource-dispatcher; sync.py creates the resources instead.
+        """Render and send the manifest to resource-dispatcher when the relation is present."""
+        if not self._is_related():
+            # Not integrated with resource-dispatcher; sync.py creates the resource instead.
             return
 
         object_storage = self._object_storage_validator.get_normalized_data()
-
-        if secrets_related:
-            self._secrets_wrapper.send_data(
-                [KubernetesManifest(self._minio_secret_manifest(object_storage))]
-            )
-        if configmaps_related:
-            self._configmaps_wrapper.send_data(
-                [KubernetesManifest(self._kfp_launcher_configmap_manifest(object_storage))]
-            )
+        self._wrapper.send_data([KubernetesManifest(self._manifest_builder(object_storage))])
 
     def get_status(self) -> StatusBase:
         """Return the component status.
 
         The component is Active unless the (already validated) object storage data cannot be
-        read while a resource-dispatcher relation is present.
+        read while the resource-dispatcher relation is present.
         """
-        if not self._is_related(self._secrets_relation_name) and not self._is_related(
-            self._configmaps_relation_name
-        ):
+        if not self._is_related():
             return ActiveStatus()
         try:
             self._object_storage_validator.get_normalized_data()

--- a/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
+++ b/charms/kfp-profile-controller/src/components/resource_dispatcher_manifests.py
@@ -1,15 +1,15 @@
 """Chisme component that sends resources to resource-dispatcher for multi-tenancy.
 
-When ``kfp-profile-controller`` is integrated with ``resource-dispatcher`` over the
-``secrets`` and/or ``configmaps`` (``kubernetes_manifest``) relations, the resources that
-are otherwise created per user-namespace by ``files/upstream/sync.py`` are instead sent to
-``resource-dispatcher`` so that it can create (and compose) them in every Profile namespace.
+When `kfp-profile-controller` is integrated with `resource-dispatcher` over the
+`secrets` and `config-maps` relations, the resources that are otherwise created per
+user-namespace by `files/upstream/sync.py` are instead sent to `resource-dispatcher`
+so that it can create them in every Profile namespace.
 
 The two relations are independent:
-  * ``secrets``    -> the ``mlpipeline-minio-artifact`` Secret
-  * ``configmaps`` -> the ``kfp-launcher`` ConfigMap
+  * `secrets`    -> the `mlpipeline-minio-artifact` Secret
+  * `config-maps`` -> handles the `kfp-launcher` ConfigMap
 
-Manifests are sent without a ``metadata.namespace`` so that ``resource-dispatcher`` treats
+Manifests are sent without a `metadata.namespace` so that `resource-dispatcher` treats
 them as global manifests and applies them to every Profile namespace.
 """
 
@@ -37,8 +37,7 @@ class ResourceDispatcherManifestsComponent(Component):
     """Sends the minio Secret and kfp-launcher ConfigMap to resource-dispatcher.
 
     This component renders and sends the manifests only for the relations that are present,
-    keeping the ``secrets`` and ``configmaps`` integrations independent. When neither relation
-    exists, the component is a no-op (the resources are created by ``sync.py`` instead).
+    keeping the `secrets` and `configmaps` integrations independent.
     """
 
     def __init__(
@@ -48,7 +47,7 @@ class ResourceDispatcherManifestsComponent(Component):
         object_storage_validator: ObjectStorageValidatorComponent,
         default_pipeline_root: str,
         secrets_relation_name: str = "secrets",
-        configmaps_relation_name: str = "configmaps",
+        configmaps_relation_name: str = "config-maps",
     ):
         """Initialise the component.
 
@@ -56,9 +55,9 @@ class ResourceDispatcherManifestsComponent(Component):
             charm: the parent charm.
             name: unique component name.
             object_storage_validator: component providing the normalized object storage data.
-            default_pipeline_root: the ``default_pipeline_root`` config value.
-            secrets_relation_name: name of the secrets endpoint. Defaults to "secrets".
-            configmaps_relation_name: name of the configmaps endpoint. Defaults to "configmaps".
+            default_pipeline_root: the `default_pipeline_root` config value.
+            secrets_relation_name: name of the secrets endpoint.
+            configmaps_relation_name: name of the configmaps endpoint.
         """
         super().__init__(charm=charm, name=name)
         self._charm = charm
@@ -109,7 +108,7 @@ class ResourceDispatcherManifestsComponent(Component):
     def _kfp_launcher_configmap_manifest(self, object_storage: dict) -> str:
         """Return the kfp-launcher ConfigMap manifest (without a namespace).
 
-        This mirrors the ``providers`` configuration built in ``files/upstream/sync.py`` so
+        This mirrors the `providers` configuration built in `files/upstream/sync.py` so
         that resource-dispatcher creates the same ConfigMap it would otherwise create.
         """
         providers_yaml = (

--- a/charms/kfp-profile-controller/src/templates/kfp_launcher_configmap.yaml.j2
+++ b/charms/kfp-profile-controller/src/templates/kfp_launcher_configmap.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kfp_launcher_configmap_name }}
+data:
+  providers: |
+    minio:
+      default:
+        endpoint: {{ endpoint }}
+        disableSSL: {{ "false" if secure else "true" }}
+        region: {{ region }}
+        forcePathStyle: true
+        credentials:
+          fromEnv: false
+          secretRef:
+            secretName: {{ minio_secret_name }}
+            accessKeyKey: accesskey
+            secretKeyKey: secretkey
+{% if default_pipeline_root %}  defaultPipelineRoot: {{ default_pipeline_root }}
+{% endif %}

--- a/charms/kfp-profile-controller/src/templates/minio_secret.yaml.j2
+++ b/charms/kfp-profile-controller/src/templates/minio_secret.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ minio_secret_name }}
+data:
+  accesskey: {{ access_key_b64 }}
+  secretkey: {{ secret_key_b64 }}

--- a/charms/kfp-profile-controller/terraform/outputs.tf
+++ b/charms/kfp-profile-controller/terraform/outputs.tf
@@ -15,6 +15,6 @@ output "requires" {
     require_cmr_mesh = "require-cmr-mesh",
     service_mesh     = "service-mesh",
     secrets          = "secrets",
-    configmaps       = "configmaps"
+    configmaps       = "config-maps"
   }
 }

--- a/charms/kfp-profile-controller/terraform/outputs.tf
+++ b/charms/kfp-profile-controller/terraform/outputs.tf
@@ -13,6 +13,8 @@ output "requires" {
     logging          = "logging",
     object_storage   = "object-storage",
     require_cmr_mesh = "require-cmr-mesh",
-    service_mesh     = "service-mesh"
+    service_mesh     = "service-mesh",
+    secrets          = "secrets",
+    configmaps       = "configmaps"
   }
 }

--- a/charms/kfp-profile-controller/tests/integration/charms_dependencies.py
+++ b/charms/kfp-profile-controller/tests/integration/charms_dependencies.py
@@ -8,6 +8,7 @@ KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="latest/edge", 
 METACONTROLLER_OPERATOR = CharmSpec(
     charm="metacontroller-operator", channel="latest/edge", trust=True
 )
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
 MINIO = CharmSpec(
     charm="minio",
     channel="latest/edge",

--- a/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_ambient.py
@@ -96,11 +96,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureReques
         trust=ADMISSION_WEBHOOK.trust,
     )
 
-    # TODO: The webhook charm must be active before the metacontroller is deployed, due to the bug
-    # described here: https://github.com/canonical/metacontroller-operator/issues/86
-    # Drop this wait_for_idle once the above issue is closed
-    await ops_test.model.wait_for_idle(apps=[ADMISSION_WEBHOOK.charm], status="active")
-
     await ops_test.model.deploy(
         entity_url=METACONTROLLER_OPERATOR.charm,
         channel=METACONTROLLER_OPERATOR.channel,

--- a/charms/kfp-profile-controller/tests/integration/test_charm_object_storage.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_object_storage.py
@@ -84,11 +84,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureReques
         trust=ADMISSION_WEBHOOK.trust,
     )
 
-    # TODO: The webhook charm must be active before the metacontroller is deployed, due to the bug
-    # described here: https://github.com/canonical/metacontroller-operator/issues/86
-    # Drop this wait_for_idle once the above issue is closed
-    await ops_test.model.wait_for_idle(apps=[ADMISSION_WEBHOOK.charm], status="active")
-
     await ops_test.model.deploy(
         entity_url=METACONTROLLER_OPERATOR.charm,
         channel=METACONTROLLER_OPERATOR.channel,

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -549,7 +549,7 @@ async def test_integrate_with_resource_dispatcher(
     When integrated with resource-dispatcher over the `secrets` and `config-maps` relations,
     the `mlpipeline-minio-artifact` Secret and `kfp-launcher` ConfigMap are created by
     resource-dispatcher (as global manifests dispatched to every Profile namespace) instead
-    of by the profile-controller's sync webhook. This test asserts they remain present.
+    of by the profile-controller's sync webhook.
     """
     await ops_test.model.deploy(
         RESOURCE_DISPATCHER.charm,

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -546,7 +546,7 @@ async def test_integrate_with_resource_dispatcher(
 ):
     """Integrate with resource-dispatcher and assert the resources are still created.
 
-    When integrated with resource-dispatcher over the `secrets` and `configmaps` relations,
+    When integrated with resource-dispatcher over the `secrets` and `config-maps` relations,
     the `mlpipeline-minio-artifact` Secret and `kfp-launcher` ConfigMap are created by
     resource-dispatcher (as global manifests dispatched to every Profile namespace) instead
     of by the profile-controller's sync webhook. This test asserts they remain present.
@@ -559,7 +559,7 @@ async def test_integrate_with_resource_dispatcher(
 
     await ops_test.model.integrate(f"{CHARM_NAME}:secrets", f"{RESOURCE_DISPATCHER.charm}:secrets")
     await ops_test.model.integrate(
-        f"{CHARM_NAME}:configmaps", f"{RESOURCE_DISPATCHER.charm}:configmaps"
+        f"{CHARM_NAME}:config-maps", f"{RESOURCE_DISPATCHER.charm}:config-maps"
     )
 
     await ops_test.model.wait_for_idle(

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -171,11 +171,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureReques
         trust=ADMISSION_WEBHOOK.trust,
     )
 
-    # TODO: The webhook charm must be active before the metacontroller is deployed, due to the bug
-    # described here: https://github.com/canonical/metacontroller-operator/issues/86
-    # Drop this wait_for_idle once the above issue is closed
-    await ops_test.model.wait_for_idle(apps=[ADMISSION_WEBHOOK.charm], status="active")
-
     await ops_test.model.deploy(
         entity_url=METACONTROLLER_OPERATOR.charm,
         channel=METACONTROLLER_OPERATOR.channel,
@@ -599,16 +594,12 @@ async def test_integrate_with_resource_dispatcher(
         trust=RESOURCE_DISPATCHER.trust,
     )
 
+    await ops_test.model.integrate(
+        "istio-beacon-k8s:service-mesh", f"{RESOURCE_DISPATCHER.charm}:service-mesh"
+    )
     await ops_test.model.integrate(f"{CHARM_NAME}:secrets", f"{RESOURCE_DISPATCHER.charm}:secrets")
     await ops_test.model.integrate(
         f"{CHARM_NAME}:config-maps", f"{RESOURCE_DISPATCHER.charm}:config-maps"
-    )
-
-    # Without this integration the beacon's waypoint proxy resets the metacontroller's
-    # POST request to resource-dispatcher (no AuthorizationPolicy exists),
-    # and the dispatched resources are never created.
-    await ops_test.model.integrate(
-        "istio-beacon-k8s:service-mesh", f"{RESOURCE_DISPATCHER.charm}:service-mesh"
     )
 
     await ops_test.model.wait_for_idle(

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -90,6 +90,48 @@ def wait_for_configmap(client: lightkube.Client, name: str, namespace: str) -> C
 
 
 @retry(stop=stop_after_delay(60 * 3), wait=wait_fixed(5), reraise=True)
+def ensure_decorator_controller_annotation(
+    resource, name: str, namespace: str, client: lightkube.Client, expected_controller: str
+):
+    """Check that a resource's decorator-controller annotation matches the expected value.
+
+    Retries for up to 3 minutes to allow metacontroller's reconciliation loop to update
+    the annotation after a relation change.
+
+    Args:
+        resource: The lightkube resource type to get (e.g. Secret, ConfigMap).
+        name: The name of the resource to check.
+        namespace: The namespace the resource is expected in.
+        client: The lightkube client to use for talking to K8s.
+        expected_controller: The expected value of the
+            `metacontroller.k8s.io/decorator-controller` annotation.
+    """
+    annotation_key = "metacontroller.k8s.io/decorator-controller"
+    logger.info(
+        "Checking annotation %s=%s on %s %s in namespace %s",
+        annotation_key,
+        expected_controller,
+        resource.__name__,
+        name,
+        namespace,
+    )
+    obj = client.get(res=resource, name=name, namespace=namespace)
+    annotations = obj.metadata.annotations or {}
+    actual = annotations.get(annotation_key)
+    assert actual == expected_controller, (
+        f"{resource.__name__} {name}: expected annotation {annotation_key}={expected_controller!r}"
+        f", got {actual!r}"
+    )
+    logger.info(
+        "%s %s has correct annotation %s=%s",
+        resource.__name__,
+        name,
+        annotation_key,
+        expected_controller,
+    )
+
+
+@retry(stop=stop_after_delay(60 * 3), wait=wait_fixed(5), reraise=True)
 def ensure_resource_exists(resource, name: str, namespace: str, client: lightkube.Client):
     """Check that a namespaced resource exists, with retries.
 
@@ -576,3 +618,46 @@ async def test_integrate_with_resource_dispatcher(
         (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
     ]:
         ensure_resource_exists(resource, name, profile, lightkube_client)
+
+    # Assert that both resources are now managed by resource-dispatcher's decorator controller.
+    for resource, name in [
+        (Secret, "mlpipeline-minio-artifact"),
+        (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
+    ]:
+        ensure_decorator_controller_annotation(
+            resource, name, profile, lightkube_client, "kubeflow-resource-dispatcher-controller"
+        )
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_resource_dispatcher_integration(
+    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
+):
+    """Remove resource-dispatcher relations and assert resources revert to profile-controller.
+
+    After removing the `secrets` and `config-maps` relations, the `mlpipeline-minio-artifact`
+    Secret and `kfp-launcher` ConfigMap should once again be managed by the profile-controller's
+    sync webhook (decorator controller: kubeflow-pipelines-profile-controller).
+    """
+    await ops_test.model.applications[CHARM_NAME].destroy_relation(
+        "secrets", f"{RESOURCE_DISPATCHER.charm}:secrets"
+    )
+    await ops_test.model.applications[CHARM_NAME].destroy_relation(
+        "config-maps", f"{RESOURCE_DISPATCHER.charm}:config-maps"
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[CHARM_NAME, RESOURCE_DISPATCHER.charm],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 10,
+    )
+
+    # Assert that both resources are once again handled by the kfp decorator controller.
+    for resource, name in [
+        (Secret, "mlpipeline-minio-artifact"),
+        (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
+    ]:
+        ensure_decorator_controller_annotation(
+            resource, name, profile, lightkube_client, "kubeflow-pipelines-profile-controller"
+        )

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -604,8 +604,15 @@ async def test_integrate_with_resource_dispatcher(
         f"{CHARM_NAME}:config-maps", f"{RESOURCE_DISPATCHER.charm}:config-maps"
     )
 
+    # Without this integration the beacon's waypoint proxy resets the metacontroller's
+    # POST request to resource-dispatcher (no AuthorizationPolicy exists),
+    # and the dispatched resources are never created.
+    await ops_test.model.integrate(
+        "istio-beacon-k8s:service-mesh", f"{RESOURCE_DISPATCHER.charm}:service-mesh"
+    )
+
     await ops_test.model.wait_for_idle(
-        apps=[CHARM_NAME, RESOURCE_DISPATCHER.charm],
+        apps=[CHARM_NAME, RESOURCE_DISPATCHER.charm, "istio-beacon-k8s"],
         status="active",
         raise_on_blocked=False,
         timeout=60 * 20,

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -52,6 +52,9 @@ CUSTOM_FRONTEND_IMAGE = "gcr.io/ml-pipeline/frontend:latest"
 CUSTOM_VISUALISATION_IMAGE = "gcr.io/ml-pipeline/visualization-server:latest"
 KFP_LAUNCHER_CONFIGMAP_KEY_FOR_DEFAULT_PIPELINE_ROOT = "defaultPipelineRoot"
 KFP_LAUNCHER_CONFIGMAP_NAME = "kfp-launcher"
+# The key used by metacontroller to specify the decoratorController that targets
+# a resource
+METACONTROLLER_ANNOTATION_KEY = "metacontroller.k8s.io/decorator-controller"
 
 PodDefault = create_namespaced_resource(
     group="kubeflow.org", version="v1alpha1", kind="PodDefault", plural="poddefaults"
@@ -106,10 +109,9 @@ def ensure_decorator_controller_annotation(
         expected_controller: The expected value of the
             `metacontroller.k8s.io/decorator-controller` annotation.
     """
-    annotation_key = "metacontroller.k8s.io/decorator-controller"
     logger.info(
         "Checking annotation %s=%s on %s %s in namespace %s",
-        annotation_key,
+        METACONTROLLER_ANNOTATION_KEY,
         expected_controller,
         resource.__name__,
         name,
@@ -117,16 +119,16 @@ def ensure_decorator_controller_annotation(
     )
     obj = client.get(res=resource, name=name, namespace=namespace)
     annotations = obj.metadata.annotations or {}
-    actual = annotations.get(annotation_key)
+    actual = annotations.get(METACONTROLLER_ANNOTATION_KEY)
     assert actual == expected_controller, (
-        f"{resource.__name__} {name}: expected annotation {annotation_key}={expected_controller!r}"
+        f"{resource.__name__} {name}: expected annotation {METACONTROLLER_ANNOTATION_KEY}={expected_controller!r}"
         f", got {actual!r}"
     )
     logger.info(
         "%s %s has correct annotation %s=%s",
         resource.__name__,
         name,
-        annotation_key,
+        METACONTROLLER_ANNOTATION_KEY,
         expected_controller,
     )
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -52,6 +52,7 @@ CUSTOM_FRONTEND_IMAGE = "gcr.io/ml-pipeline/frontend:latest"
 CUSTOM_VISUALISATION_IMAGE = "gcr.io/ml-pipeline/visualization-server:latest"
 KFP_LAUNCHER_CONFIGMAP_KEY_FOR_DEFAULT_PIPELINE_ROOT = "defaultPipelineRoot"
 KFP_LAUNCHER_CONFIGMAP_NAME = "kfp-launcher"
+MLPIPELINE_SECRET_NAME = "mlpipeline-minio-artifact"
 # The key used by metacontroller to specify the decoratorController that targets
 # a resource
 METACONTROLLER_ANNOTATION_KEY = "metacontroller.k8s.io/decorator-controller"
@@ -615,14 +616,14 @@ async def test_integrate_with_resource_dispatcher(
     # The resources are dispatched asynchronously to the Profile namespace; retry to allow
     # resource-dispatcher's reconciliation loop to create them.
     for resource, name in [
-        (Secret, "mlpipeline-minio-artifact"),
+        (Secret, MLPIPELINE_SECRET_NAME),
         (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
     ]:
         ensure_resource_exists(resource, name, profile, lightkube_client)
 
     # Assert that both resources are now managed by resource-dispatcher's decorator controller.
     for resource, name in [
-        (Secret, "mlpipeline-minio-artifact"),
+        (Secret, MLPIPELINE_SECRET_NAME),
         (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
     ]:
         ensure_decorator_controller_annotation(
@@ -656,7 +657,7 @@ async def test_remove_resource_dispatcher_integration(
 
     # Assert that both resources are once again handled by the kfp decorator controller.
     for resource, name in [
-        (Secret, "mlpipeline-minio-artifact"),
+        (Secret, MLPIPELINE_SECRET_NAME),
         (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
     ]:
         ensure_decorator_controller_annotation(

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -25,6 +25,7 @@ from charms_dependencies import (
     ADMISSION_WEBHOOK,
     KUBEFLOW_PROFILES,
     METACONTROLLER_OPERATOR,
+    RESOURCE_DISPATCHER,
     S3_INTEGRATOR,
 )
 from lightkube import ApiError, codecs
@@ -86,6 +87,37 @@ def wait_for_configmap(client: lightkube.Client, name: str, namespace: str) -> C
         with attempt:
             return client.get(res=ConfigMap, name=name, namespace=namespace)
     raise TimeoutError(f"ConfigMap {name} in namespace {namespace} not present.")
+
+
+@retry(stop=stop_after_delay(60 * 3), wait=wait_fixed(5), reraise=True)
+def ensure_resource_exists(resource, name: str, namespace: str, client: lightkube.Client):
+    """Check that a namespaced resource exists, with retries.
+
+    The retries will catch the 404 errors if the resource doesn't exist yet (e.g. while
+    resource-dispatcher is still reconciling and creating it in the Profile namespace).
+
+    Args:
+        resource: The lightkube resource type to get (e.g. Secret, ConfigMap).
+        name: The name of the resource to check for.
+        namespace: The namespace the resource is expected in.
+        client: The lightkube client to use for talking to K8s.
+
+    Raises:
+        ApiError: From lightkube, if there was an error aside from 404.
+    """
+    logger.info("Checking if %s %s exists in namespace %s", resource.__name__, name, namespace)
+    try:
+        client.get(res=resource, name=name, namespace=namespace)
+        logger.info("%s %s exists in namespace %s!", resource.__name__, name, namespace)
+    except ApiError as e:
+        if e.status.code == 404:
+            logger.info(
+                "%s %s doesn't exist in namespace %s, retrying...",
+                resource.__name__,
+                name,
+                namespace,
+            )
+        raise
 
 
 @pytest.mark.abort_on_fail
@@ -506,3 +538,41 @@ async def test_container_security_context(
         CONTAINERS_SECURITY_CONTEXT_MAP,
         ops_test.model.name,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_integrate_with_resource_dispatcher(
+    ops_test: OpsTest, lightkube_client: lightkube.Client, profile: str
+):
+    """Integrate with resource-dispatcher and assert the resources are still created.
+
+    When integrated with resource-dispatcher over the `secrets` and `configmaps` relations,
+    the `mlpipeline-minio-artifact` Secret and `kfp-launcher` ConfigMap are created by
+    resource-dispatcher (as global manifests dispatched to every Profile namespace) instead
+    of by the profile-controller's sync webhook. This test asserts they remain present.
+    """
+    await ops_test.model.deploy(
+        RESOURCE_DISPATCHER.charm,
+        channel=RESOURCE_DISPATCHER.channel,
+        trust=RESOURCE_DISPATCHER.trust,
+    )
+
+    await ops_test.model.integrate(f"{CHARM_NAME}:secrets", f"{RESOURCE_DISPATCHER.charm}:secrets")
+    await ops_test.model.integrate(
+        f"{CHARM_NAME}:configmaps", f"{RESOURCE_DISPATCHER.charm}:configmaps"
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[CHARM_NAME, RESOURCE_DISPATCHER.charm],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 20,
+    )
+
+    # The resources are dispatched asynchronously to the Profile namespace; retry to allow
+    # resource-dispatcher's reconciliation loop to create them.
+    for resource, name in [
+        (Secret, "mlpipeline-minio-artifact"),
+        (ConfigMap, KFP_LAUNCHER_CONFIGMAP_NAME),
+    ]:
+        ensure_resource_exists(resource, name, profile, lightkube_client)

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -145,8 +145,8 @@ def ensure_resource_exists(resource, name: str, namespace: str, client: lightkub
         client: The lightkube client to use for talking to K8s.
 
     Raises:
-        ApiError: From lightkube, if there was an error aside from 404.
-    """
+        ApiError: From lightkube (including 404 while waiting for the resource to appear).
+
     logger.info("Checking if %s %s exists in namespace %s", resource.__name__, name, namespace)
     try:
         client.get(res=resource, name=name, namespace=namespace)

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -146,6 +146,7 @@ def ensure_resource_exists(resource, name: str, namespace: str, client: lightkub
 
     Raises:
         ApiError: From lightkube (including 404 while waiting for the resource to appear).
+    """
 
     logger.info("Checking if %s %s exists in namespace %s", resource.__name__, name, namespace)
     try:

--- a/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm_s3.py
@@ -122,7 +122,8 @@ def ensure_decorator_controller_annotation(
     annotations = obj.metadata.annotations or {}
     actual = annotations.get(METACONTROLLER_ANNOTATION_KEY)
     assert actual == expected_controller, (
-        f"{resource.__name__} {name}: expected annotation {METACONTROLLER_ANNOTATION_KEY}={expected_controller!r}"
+        f"{resource.__name__} {name}: expected annotation"
+        f" {METACONTROLLER_ANNOTATION_KEY}={expected_controller!r}"
         f", got {actual!r}"
     )
     logger.info(

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -913,14 +913,15 @@ def test_no_manifests_sent_without_resource_dispatcher_relations(
     harness.begin()
     _mock_object_storage_data(harness)
 
-    component = harness.charm.resource_dispatcher_manifests.component
-    component._secrets_wrapper.send_data = MagicMock()
-    component._configmaps_wrapper.send_data = MagicMock()
+    secrets_component = harness.charm.resource_dispatcher_secrets.component
+    configmaps_component = harness.charm.resource_dispatcher_configmaps.component
+    secrets_component._wrapper.send_data = MagicMock()
+    configmaps_component._wrapper.send_data = MagicMock()
 
     harness.charm.on.install.emit()
 
-    component._secrets_wrapper.send_data.assert_not_called()
-    component._configmaps_wrapper.send_data.assert_not_called()
+    secrets_component._wrapper.send_data.assert_not_called()
+    configmaps_component._wrapper.send_data.assert_not_called()
 
 
 def test_secret_manifest_sent_when_secrets_related(
@@ -931,16 +932,17 @@ def test_secret_manifest_sent_when_secrets_related(
     harness.begin()
     _mock_object_storage_data(harness)
 
-    component = harness.charm.resource_dispatcher_manifests.component
-    component._secrets_wrapper.send_data = MagicMock()
-    component._configmaps_wrapper.send_data = MagicMock()
+    secrets_component = harness.charm.resource_dispatcher_secrets.component
+    configmaps_component = harness.charm.resource_dispatcher_configmaps.component
+    secrets_component._wrapper.send_data = MagicMock()
+    configmaps_component._wrapper.send_data = MagicMock()
 
     harness.add_relation("secrets", "resource-dispatcher")
     harness.charm.on.install.emit()
 
-    component._configmaps_wrapper.send_data.assert_not_called()
-    component._secrets_wrapper.send_data.assert_called()
-    sent_manifests = component._secrets_wrapper.send_data.call_args.args[0]
+    configmaps_component._wrapper.send_data.assert_not_called()
+    secrets_component._wrapper.send_data.assert_called()
+    sent_manifests = secrets_component._wrapper.send_data.call_args.args[0]
     manifest = yaml.safe_load(sent_manifests[0].manifest_content)
     assert manifest["kind"] == "Secret"
     assert manifest["metadata"]["name"] == "mlpipeline-minio-artifact"
@@ -959,16 +961,17 @@ def test_configmap_manifest_sent_when_configmaps_related(
     harness.begin()
     _mock_object_storage_data(harness)
 
-    component = harness.charm.resource_dispatcher_manifests.component
-    component._secrets_wrapper.send_data = MagicMock()
-    component._configmaps_wrapper.send_data = MagicMock()
+    secrets_component = harness.charm.resource_dispatcher_secrets.component
+    configmaps_component = harness.charm.resource_dispatcher_configmaps.component
+    secrets_component._wrapper.send_data = MagicMock()
+    configmaps_component._wrapper.send_data = MagicMock()
 
     harness.add_relation("config-maps", "resource-dispatcher")
     harness.charm.on.install.emit()
 
-    component._secrets_wrapper.send_data.assert_not_called()
-    component._configmaps_wrapper.send_data.assert_called()
-    sent_manifests = component._configmaps_wrapper.send_data.call_args.args[0]
+    secrets_component._wrapper.send_data.assert_not_called()
+    configmaps_component._wrapper.send_data.assert_called()
+    sent_manifests = configmaps_component._wrapper.send_data.call_args.args[0]
     manifest = yaml.safe_load(sent_manifests[0].manifest_content)
     assert manifest["kind"] == "ConfigMap"
     assert manifest["metadata"]["name"] == "kfp-launcher"

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -898,7 +898,7 @@ def test_manage_flags_track_resource_dispatcher_relations(
     if add_secrets:
         harness.add_relation("secrets", "resource-dispatcher")
     if add_configmaps:
-        harness.add_relation("configmaps", "resource-dispatcher")
+        harness.add_relation("config-maps", "resource-dispatcher")
 
     harness.charm.on.install.emit()
 
@@ -970,7 +970,7 @@ def test_configmap_manifest_sent_when_configmaps_related(
     component._secrets_wrapper.send_data = MagicMock()
     component._configmaps_wrapper.send_data = MagicMock()
 
-    harness.add_relation("configmaps", "resource-dispatcher")
+    harness.add_relation("config-maps", "resource-dispatcher")
     harness.charm.on.install.emit()
 
     component._secrets_wrapper.send_data.assert_not_called()

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import base64
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -80,7 +81,7 @@ def generate_expected_environment(model_name: str, kfp_api_sa: str = "kfp-api") 
         # ambient
         "AMBIENT_ENABLED": False,
         "KFP_API_PRINCIPAL": f"cluster.local/ns/{model_name}/sa/{kfp_api_sa}",
-        # By default (no resource-dispatcher relations) sync.py manages these resources.
+        # Values for multi-tenancy resources (based on active relations with resource-dispatcher)
         "MANAGE_MINIO_SECRET": "true",
         "MANAGE_KFP_LAUNCHER_CONFIGMAP": "true",
     }
@@ -851,14 +852,6 @@ def test_object_storage_validator_blocks_with_invalid_s3_endpoint(
     assert isinstance(harness.charm.object_storage_validator.component.get_status(), BlockedStatus)
 
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# resource-dispatcher (multi-tenancy) integration tests
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-import base64  # noqa: E402
-
-import yaml as _yaml  # noqa: E402
-
-
 def _mock_object_storage_data(harness: Harness) -> None:
     """Make the object-storage validator return usable, complete data."""
     harness.charm.leadership_gate.get_status = MagicMock(return_value=ActiveStatus())
@@ -880,7 +873,7 @@ def _mock_object_storage_data(harness: Harness) -> None:
         pytest.param(True, True, "false", "false", id="both"),
     ],
 )
-def test_manage_flags_track_resource_dispatcher_relations(
+def test_manage_flags_follow_resource_dispatcher_relations(
     harness: Harness,
     mocked_lightkube_client,
     mocked_kubernetes_service_patch,
@@ -933,7 +926,7 @@ def test_no_manifests_sent_without_resource_dispatcher_relations(
 def test_secret_manifest_sent_when_secrets_related(
     harness: Harness, mocked_lightkube_client, mocked_kubernetes_service_patch
 ):
-    """When the secrets relation exists, the minio Secret manifest is sent (no namespace)."""
+    """When the secrets relation exists, the minio Secret manifest is sent."""
     harness.set_leader(True)
     harness.begin()
     _mock_object_storage_data(harness)
@@ -948,7 +941,7 @@ def test_secret_manifest_sent_when_secrets_related(
     component._configmaps_wrapper.send_data.assert_not_called()
     component._secrets_wrapper.send_data.assert_called()
     sent_manifests = component._secrets_wrapper.send_data.call_args.args[0]
-    manifest = _yaml.safe_load(sent_manifests[0].manifest_content)
+    manifest = yaml.safe_load(sent_manifests[0].manifest_content)
     assert manifest["kind"] == "Secret"
     assert manifest["metadata"]["name"] == "mlpipeline-minio-artifact"
     # Global manifest: no namespace so resource-dispatcher applies it to all Profiles
@@ -976,7 +969,7 @@ def test_configmap_manifest_sent_when_configmaps_related(
     component._secrets_wrapper.send_data.assert_not_called()
     component._configmaps_wrapper.send_data.assert_called()
     sent_manifests = component._configmaps_wrapper.send_data.call_args.args[0]
-    manifest = _yaml.safe_load(sent_manifests[0].manifest_content)
+    manifest = yaml.safe_load(sent_manifests[0].manifest_content)
     assert manifest["kind"] == "ConfigMap"
     assert manifest["metadata"]["name"] == "kfp-launcher"
     assert "namespace" not in manifest["metadata"]

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -80,6 +80,9 @@ def generate_expected_environment(model_name: str, kfp_api_sa: str = "kfp-api") 
         # ambient
         "AMBIENT_ENABLED": False,
         "KFP_API_PRINCIPAL": f"cluster.local/ns/{model_name}/sa/{kfp_api_sa}",
+        # By default (no resource-dispatcher relations) sync.py manages these resources.
+        "MANAGE_MINIO_SECRET": "true",
+        "MANAGE_KFP_LAUNCHER_CONFIGMAP": "true",
     }
 
 
@@ -846,3 +849,136 @@ def test_object_storage_validator_blocks_with_invalid_s3_endpoint(
     )
 
     assert isinstance(harness.charm.object_storage_validator.component.get_status(), BlockedStatus)
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# resource-dispatcher (multi-tenancy) integration tests
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+import base64  # noqa: E402
+
+import yaml as _yaml  # noqa: E402
+
+
+def _mock_object_storage_data(harness: Harness) -> None:
+    """Make the object-storage validator return usable, complete data."""
+    harness.charm.leadership_gate.get_status = MagicMock(return_value=ActiveStatus())
+    harness.charm.s3_relations_conflict_detector.get_status = MagicMock(
+        return_value=ActiveStatus()
+    )
+    harness.charm.object_storage_relation.component.get_data = MagicMock(
+        return_value=MOCK_OBJECT_STORAGE_DATA
+    )
+    harness.charm.kubernetes_resources.get_status = MagicMock(return_value=ActiveStatus())
+
+
+@pytest.mark.parametrize(
+    "add_secrets, add_configmaps, expected_manage_secret, expected_manage_configmap",
+    [
+        pytest.param(False, False, "true", "true", id="no-relations"),
+        pytest.param(True, False, "false", "true", id="secrets-only"),
+        pytest.param(False, True, "true", "false", id="configmaps-only"),
+        pytest.param(True, True, "false", "false", id="both"),
+    ],
+)
+def test_manage_flags_track_resource_dispatcher_relations(
+    harness: Harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+    add_secrets,
+    add_configmaps,
+    expected_manage_secret,
+    expected_manage_configmap,
+):
+    """The MANAGE_* env flags flip to 'false' when the matching relation exists."""
+    harness.set_leader(True)
+    harness.begin()
+    harness.set_can_connect("kfp-profile-controller", True)
+    _mock_object_storage_data(harness)
+
+    if add_secrets:
+        harness.add_relation("secrets", "resource-dispatcher")
+    if add_configmaps:
+        harness.add_relation("configmaps", "resource-dispatcher")
+
+    harness.charm.on.install.emit()
+
+    environment = (
+        harness.charm.unit.get_container("kfp-profile-controller")
+        .get_plan()
+        .services["kfp-profile-controller"]
+        .environment
+    )
+    assert environment["MANAGE_MINIO_SECRET"] == expected_manage_secret
+    assert environment["MANAGE_KFP_LAUNCHER_CONFIGMAP"] == expected_manage_configmap
+
+
+def test_no_manifests_sent_without_resource_dispatcher_relations(
+    harness: Harness, mocked_lightkube_client, mocked_kubernetes_service_patch
+):
+    """When neither relation exists, no manifests are sent to resource-dispatcher."""
+    harness.set_leader(True)
+    harness.begin()
+    _mock_object_storage_data(harness)
+
+    component = harness.charm.resource_dispatcher_manifests.component
+    component._secrets_wrapper.send_data = MagicMock()
+    component._configmaps_wrapper.send_data = MagicMock()
+
+    harness.charm.on.install.emit()
+
+    component._secrets_wrapper.send_data.assert_not_called()
+    component._configmaps_wrapper.send_data.assert_not_called()
+
+
+def test_secret_manifest_sent_when_secrets_related(
+    harness: Harness, mocked_lightkube_client, mocked_kubernetes_service_patch
+):
+    """When the secrets relation exists, the minio Secret manifest is sent (no namespace)."""
+    harness.set_leader(True)
+    harness.begin()
+    _mock_object_storage_data(harness)
+
+    component = harness.charm.resource_dispatcher_manifests.component
+    component._secrets_wrapper.send_data = MagicMock()
+    component._configmaps_wrapper.send_data = MagicMock()
+
+    harness.add_relation("secrets", "resource-dispatcher")
+    harness.charm.on.install.emit()
+
+    component._configmaps_wrapper.send_data.assert_not_called()
+    component._secrets_wrapper.send_data.assert_called()
+    sent_manifests = component._secrets_wrapper.send_data.call_args.args[0]
+    manifest = _yaml.safe_load(sent_manifests[0].manifest_content)
+    assert manifest["kind"] == "Secret"
+    assert manifest["metadata"]["name"] == "mlpipeline-minio-artifact"
+    # Global manifest: no namespace so resource-dispatcher applies it to all Profiles
+    assert "namespace" not in manifest["metadata"]
+    assert manifest["data"]["accesskey"] == base64.b64encode(
+        MOCK_OBJECT_STORAGE_DATA["access-key"].encode("utf-8")
+    ).decode("utf-8")
+
+
+def test_configmap_manifest_sent_when_configmaps_related(
+    harness: Harness, mocked_lightkube_client, mocked_kubernetes_service_patch
+):
+    """When the configmaps relation exists, the kfp-launcher ConfigMap manifest is sent."""
+    harness.set_leader(True)
+    harness.begin()
+    _mock_object_storage_data(harness)
+
+    component = harness.charm.resource_dispatcher_manifests.component
+    component._secrets_wrapper.send_data = MagicMock()
+    component._configmaps_wrapper.send_data = MagicMock()
+
+    harness.add_relation("configmaps", "resource-dispatcher")
+    harness.charm.on.install.emit()
+
+    component._secrets_wrapper.send_data.assert_not_called()
+    component._configmaps_wrapper.send_data.assert_called()
+    sent_manifests = component._configmaps_wrapper.send_data.call_args.args[0]
+    manifest = _yaml.safe_load(sent_manifests[0].manifest_content)
+    assert manifest["kind"] == "ConfigMap"
+    assert manifest["metadata"]["name"] == "kfp-launcher"
+    assert "namespace" not in manifest["metadata"]
+    assert "providers" in manifest["data"]
+    assert manifest["data"]["defaultPipelineRoot"] == KFP_DEFAULT_PIPELINE_ROOT

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -1005,10 +1005,12 @@ def test_resource_dispatcher_component_status(
     storage_ok,
     expected_status,
 ):
-    """The component is Active unless its relation is present but object storage is unreadable.
+    """Verify the status returned by each ResourceDispatcherManifestsComponent instance.
 
-    When the relation is absent, sync.py owns the resource and the component stays Active
-    regardless of the object storage data.
+    For both the `secrets` and `config-maps` relations, covers the three cases:
+      * relation absent -> ActiveStatus (sync.py owns the resource; object storage is not needed)
+      * relation present and object storage readable -> ActiveStatus
+      * relation present but object storage unreadable -> BlockedStatus
     """
     harness.begin()
     harness.charm.object_storage_relation.component.get_data = MagicMock(

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -978,3 +978,44 @@ def test_configmap_manifest_sent_when_configmaps_related(
     assert "namespace" not in manifest["metadata"]
     assert "providers" in manifest["data"]
     assert manifest["data"]["defaultPipelineRoot"] == KFP_DEFAULT_PIPELINE_ROOT
+
+
+@pytest.mark.parametrize(
+    "component_attr, relation_name",
+    [
+        pytest.param("resource_dispatcher_secrets", "secrets", id="secrets"),
+        pytest.param("resource_dispatcher_configmaps", "config-maps", id="config-maps"),
+    ],
+)
+@pytest.mark.parametrize(
+    "related, storage_ok, expected_status",
+    [
+        pytest.param(False, False, ActiveStatus, id="not-related-active"),
+        pytest.param(True, True, ActiveStatus, id="related-storage-ok-active"),
+        pytest.param(True, False, BlockedStatus, id="related-storage-broken-blocked"),
+    ],
+)
+def test_resource_dispatcher_component_status(
+    harness: Harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+    component_attr,
+    relation_name,
+    related,
+    storage_ok,
+    expected_status,
+):
+    """The component is Active unless its relation is present but object storage is unreadable.
+
+    When the relation is absent, sync.py owns the resource and the component stays Active
+    regardless of the object storage data.
+    """
+    harness.begin()
+    harness.charm.object_storage_relation.component.get_data = MagicMock(
+        return_value=MOCK_OBJECT_STORAGE_DATA if storage_ok else {}
+    )
+    if related:
+        harness.add_relation(relation_name, "resource-dispatcher")
+
+    component = getattr(harness.charm, component_attr).component
+    assert isinstance(component.get_status(), expected_status)

--- a/tests/integration/test_kfp_functional_s3.py
+++ b/tests/integration/test_kfp_functional_s3.py
@@ -118,9 +118,6 @@ def test_deploy(juju: jubilant.Juju, request: pytest.FixtureRequest, lightkube_c
     # Deploy the kfp-operators bundle from the rendered bundle file
     juju.deploy(rendered_bundle, trust=True)
 
-    log.info("Waiting on model applications and units to be idle")
-    juju.wait(jubilant.all_agents_idle, delay=5.0)
-
     # Deploy s3-integrator backed by microceph and configure it with generated credentials.
     log.info("Deploying s3-integrator with microceph backend")
 


### PR DESCRIPTION
## Summary
- Add relations with `config-maps` and `secrets` via the `kubernetes_manifest` interface. Use a new `ResourceDispatcherManifestsComponent` `chisme` component for the logic.
- Update Terraform module with new outputs
- Update `sync.py` to conditionally create the `mlpipeline-minio-artifact` Secret and `kfp-launcher` ConfigMap depending on the presence of relations with `resource-dispatcher`. 
  - If no integration exists, then these resources are created.
  - If an integration with `resource-dispatcher` exists, then these resources should be created by `resource-dispatcher`
- Update integration test `test_charm_s3.py`:
  - Integrate with `resource-dispatcher`, and ensure that the resources are now handled by the `resource-dispatcher` decoratorController
  - Remove the integration with `resource-dispatcher`, and ensure that the resources are once again created by the kfp decoratorContoller

## Notes
- Removed an extra `wait_for_idle` in the integration tests since the [respective issue](https://github.com/canonical/metacontroller-operator/issues/86) has been closed. This should save some time on the integration tests.
- Updated the extra wait for idle in the bundle integration tests for S3 storage before deploying `s3-integrator`, which should also save some time on the integration tests.

Closes #953 