### PR TITLE
feat: Remove deprecated 'mysql' endpoint

### DIFF
--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -20,9 +20,6 @@ resources:
     description: Backing OCI image
     upstream-source: docker.io/charmedkubeflow/api-server:2.16.0-4d8c239
 requires:
-  mysql:
-    interface: mysql
-    limit: 1
   relational-db:
     interface: mysql_client
     limit: 1

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -729,9 +729,9 @@ class KfpApiOperator(CharmBase):
         db_data = {}
         try:
             db_data = self._get_relational_db_data()
-        except ErrorWithStatus as err:
-            # relation-db relation is established, but data could not be retrieved
-            raise err
+        except ErrorWithStatus:
+            # relational-db relation is established, but data could not be retrieved
+            raise
         except GenericCharmRuntimeError:
             # relational-db relation is not established, raise error
             raise ErrorWithStatus(

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -69,8 +69,6 @@ K8S_RESOURCE_FILES = [
     "src/templates/auth_manifests.yaml.j2",
     "src/templates/ml-pipeline-service.yaml.j2",
 ]
-MYSQL_WARNING = "Relation mysql is deprecated."
-UNBLOCK_MESSAGE = "Remove deprecated mysql relation to unblock."
 KFP_API_SERVICE_NAME = "apiserver"
 # The waypoint name format should match the format set by istio-beacon-k8s
 # See how the label is generated:
@@ -139,10 +137,6 @@ class KfpApiOperator(CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade)
         self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on["mysql"].relation_joined, self._on_mysql_relation)
-        self.framework.observe(self.on["mysql"].relation_changed, self._on_mysql_relation)
-        self.framework.observe(self.on["mysql"].relation_departed, self._on_mysql_relation_remove)
-        self.framework.observe(self.on["mysql"].relation_broken, self._on_mysql_relation_remove)
         self.framework.observe(
             self.on["relational-db"].relation_joined, self._on_relational_db_relation
         )
@@ -352,7 +346,7 @@ class KfpApiOperator(CharmBase):
 
         Configuration is generated based on:
         - Supplied interfaces.
-        - Database data: from MySQL relation data or from data platform library.
+        - Database data: from `relational-db` relation.
         - Model configuration.
 
         Return:
@@ -686,38 +680,6 @@ class KfpApiOperator(CharmBase):
 
         return relation
 
-    def _get_mysql_data(self) -> dict:
-        """Check mysql relation, retrieve and return data, if available."""
-        db_data = {}
-        relation_data = {}
-        relation = self._get_db_relation("mysql")
-
-        # retrieve database data from relation
-        try:
-            unit = next(iter(relation.units))
-            relation_data = relation.data[unit]
-            # retrieve database data from relation data
-            # this also validates the expected data by means of KeyError exception
-            db_data["db_name"] = relation_data["database"]
-            db_data["db_password"] = relation_data["root_password"]
-            db_data["db_username"] = "root"
-            db_data["db_host"] = relation_data["host"]
-            db_data["db_port"] = relation_data["port"]
-        except (IndexError, StopIteration, KeyError) as err:
-            # failed to retrieve database configuration
-            if not relation_data:
-                raise GenericCharmRuntimeError(
-                    "Database relation mysql is not established or empty"
-                )
-            self.logger.error(f"Missing attribute {err} in mysql relation data")
-            # incorrect/incomplete data can be found in mysql relation which can be resolved:
-            # use WaitingStatus
-            raise ErrorWithStatus(
-                "Incorrect/incomplete data found in relation mysql. See logs", WaitingStatus
-            )
-
-        return db_data
-
     def _get_relational_db_data(self) -> dict:
         """Check relational-db relation, retrieve and return data, if available."""
         db_data = {}
@@ -749,7 +711,7 @@ class KfpApiOperator(CharmBase):
                 db_data["db_port"] = port
             except KeyError as err:
                 self.logger.error(f"Missing attribute {err} in relational-db relation data")
-                # incorrect/incomplete data can be found in mysql relation which can be
+                # incorrect/incomplete data can be found in `relational-db` relation which can be
                 # resolved: use WaitingStatus
                 raise ErrorWithStatus(
                     "Incorrect/incomplete data found in relation relational-db. See logs",
@@ -763,28 +725,18 @@ class KfpApiOperator(CharmBase):
         return db_data
 
     def _get_db_data(self) -> dict:
-        """Check for MySQL relations -  mysql or relational-db - and retrieve data.
-
-        Only one database relation can be established at a time.
-        """
+        """Check for the relational-db relation and retrieve data."""
         db_data = {}
         try:
-            db_data = self._get_mysql_data()
+            db_data = self._get_relational_db_data()
         except ErrorWithStatus as err:
-            # mysql relation is established, but data could not be retrieved
+            # relation-db relation is established, but data could not be retrieved
             raise err
         except GenericCharmRuntimeError:
-            # mysql relation is not established, proceed to check for relational-db relation
-            try:
-                db_data = self._get_relational_db_data()
-            except ErrorWithStatus as err:
-                # relation-db relation is established, but data could not be retrieved
-                raise err
-            except GenericCharmRuntimeError:
-                # mysql and relational-db relations are not established, raise error
-                raise ErrorWithStatus(
-                    "Please add required database relation: eg. relational-db", BlockedStatus
-                )
+            # relational-db relation is not established, raise error
+            raise ErrorWithStatus(
+                "Please add required `relational-db` database relation.", BlockedStatus
+            )
 
         return db_data
 
@@ -875,51 +827,8 @@ class KfpApiOperator(CharmBase):
 
         self.model.unit.status = ActiveStatus()
 
-    def _on_mysql_relation(self, event):
-        """Check for existing database relations and process mysql relation if needed."""
-        # check for too many mysql relations
-        mysql = self.model.relations["mysql"]
-        if len(mysql) > 1:
-            raise ErrorWithStatus(f"Too many mysql relations. {MYSQL_WARNING}", BlockedStatus)
-
-        # check for relational-db relation
-        # relying on KeyError to ensure that relational-db relation is not present
-        try:
-            relation = self.model.get_relation("relational-db")
-            if relation:
-                self.logger.warning(
-                    "Up-to-date database relation relational-db is already established."
-                )
-                self.logger.error(f"{MYSQL_WARNING} {UNBLOCK_MESSAGE}")
-                self.model.unit.status = BlockedStatus(f"{UNBLOCK_MESSAGE} See logs")
-                return
-        except KeyError:
-            pass
-        # relational-db relation was not found, proceed with warnings
-        self.logger.warning(MYSQL_WARNING)
-        self.model.unit.status = MaintenanceStatus(f"Adding mysql relation. {MYSQL_WARNING}")
-        self._on_event(event)
-
-    def _on_mysql_relation_remove(self, event):
-        """Process removal of mysql relation."""
-        self.model.unit.status = MaintenanceStatus(f"Removing mysql relation. {MYSQL_WARNING}")
-        self._on_event(event)
-
     def _on_relational_db_relation(self, event):
-        """Check for existing database relations and process relational-db relation if needed."""
-        # relying on KeyError to ensure that mysql relation is not present
-        try:
-            relation = self.model.get_relation("mysql")
-            if relation:
-                self.logger.warning(
-                    "Failed to create relational-db relation due to existing mysql relation."
-                )
-                self.logger.error(f"{MYSQL_WARNING} {UNBLOCK_MESSAGE}")
-                self.model.unit.status = BlockedStatus(f"{UNBLOCK_MESSAGE} See logs")
-                return
-        except KeyError:
-            pass
-        # mysql relation was not found, proceed
+        """Process relational-db relation."""
         self.model.unit.status = MaintenanceStatus("Adding relational-db relation")
         self._on_event(event)
 

--- a/charms/kfp-api/src/charm.py
+++ b/charms/kfp-api/src/charm.py
@@ -730,7 +730,7 @@ class KfpApiOperator(CharmBase):
         try:
             db_data = self._get_relational_db_data()
         except ErrorWithStatus:
-            # relational-db relation is established, but data could not be retrieved
+            # preserve relational-db retrieval errors with their original traceback
             raise
         except GenericCharmRuntimeError:
             # relational-db relation is not established, raise error

--- a/charms/kfp-api/terraform/outputs.tf
+++ b/charms/kfp-api/terraform/outputs.tf
@@ -16,7 +16,6 @@ output "requires" {
   value = {
     kfp_viz          = "kfp-viz",
     logging          = "logging",
-    mysql            = "mysql",
     object_storage   = "object-storage",
     relational_db    = "relational-db",
     require_cmr_mesh = "require-cmr-mesh",

--- a/charms/kfp-api/tests/unit/test_operator.py
+++ b/charms/kfp-api/tests/unit/test_operator.py
@@ -266,101 +266,6 @@ class TestCharm:
             harness.update_config(config)
             harness.charm._check_config()
 
-    @pytest.mark.parametrize(
-        "relation_data,expected_returned_data,expected_raises,expected_status",
-        (
-            (
-                # No relation established.  Raises ErrorWithStatus
-                None,
-                None,
-                pytest.raises(ErrorWithStatus),
-                BlockedStatus("Please add required relation relation mysql"),
-            ),
-            (
-                # Relation exists but no data posted yet
-                {},
-                None,
-                pytest.raises(ErrorWithStatus),
-                WaitingStatus("Waiting for mysql relation data"),
-            ),
-            (
-                # Relation exists with only partial data
-                {"database": "database"},
-                None,
-                pytest.raises(ErrorWithStatus),
-                BlockedStatus("Received incomplete data from mysql relation. See logs"),
-            ),
-            (
-                # Relation complete
-                {
-                    "database": "database",
-                    "host": "host",
-                    "root_password": "root_password",
-                    "port": "port",
-                },
-                {
-                    "database": "database",
-                    "host": "host",
-                    "root_password": "root_password",
-                    "port": "port",
-                },
-                does_not_raise(),
-                None,
-            ),
-        ),
-    )
-    @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    def test_mysql_relation(
-        self,
-        relation_data,
-        expected_returned_data,
-        expected_raises,
-        expected_status,
-        harness: Harness,
-        mocked_resource_handler,
-        mocked_lightkube_client,
-    ):
-        harness.set_leader(True)
-        harness.begin()
-        harness.container_pebble_ready(KFP_API_CONTAINER_NAME)
-
-        mysql_app = "mysql_app"
-        mysql_unit = f"{mysql_app}/0"
-
-        rel_id = harness.add_relation("mysql", mysql_app)
-        harness.add_relation_unit(rel_id, mysql_unit)
-
-        # Test complete relation
-        data = {
-            "database": "database",
-            "host": "host",
-            "root_password": "root_password",
-            "port": "port",
-        }
-        harness.update_relation_data(rel_id, mysql_unit, data)
-        with does_not_raise():
-            harness.charm._get_db_data()
-
-    @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    def test_mysql_relation_too_many_relations(
-        self, harness: Harness, mocked_resource_handler, mocked_lightkube_client
-    ):
-        harness.set_leader(True)
-        harness.begin()
-        harness.container_pebble_ready(KFP_API_CONTAINER_NAME)
-
-        mysql_app = "mysql_app"
-        mysql_unit = f"{mysql_app}/0"
-
-        rel_id = harness.add_relation("mysql", mysql_app)
-        harness.add_relation_unit(rel_id, mysql_unit)
-        rel_id_2 = harness.add_relation("mysql", "extra_sql")
-        with pytest.raises(ErrorWithStatus) as too_many_relations:
-            harness.add_relation_unit(rel_id_2, "extra_sql/0")
-        assert too_many_relations.value.status == BlockedStatus(
-            "Too many mysql relations. Relation mysql is deprecated."
-        )
-
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def test_kfp_viz_relation_missing(
         self, harness: Harness, mocked_resource_handler, mocked_lightkube_client
@@ -568,7 +473,7 @@ class TestCharm:
 
         # Set up required relations
         (
-            mysql_data,
+            relational_db_data,
             objectstorage_data,
             kfp_viz_data,
             kfpapi_rel_id,
@@ -639,11 +544,11 @@ class TestCharm:
             "OBJECTSTORECONFIG_BUCKETNAME": harness.charm.config["object-store-bucket-name"],
             "DBCONFIG_CONMAXLIFETIME": "120s",
             "DB_DRIVER_NAME": "mysql",
-            "DBCONFIG_MYSQLCONFIG_USER": "root",
-            "DBCONFIG_MYSQLCONFIG_PASSWORD": mysql_data["root_password"],
-            "DBCONFIG_MYSQLCONFIG_DBNAME": mysql_data["database"],
-            "DBCONFIG_MYSQLCONFIG_HOST": mysql_data["host"],
-            "DBCONFIG_MYSQLCONFIG_PORT": mysql_data["port"],
+            "DBCONFIG_MYSQLCONFIG_USER": relational_db_data["username"],
+            "DBCONFIG_MYSQLCONFIG_PASSWORD": relational_db_data["password"],
+            "DBCONFIG_MYSQLCONFIG_DBNAME": relational_db_data["database"],
+            "DBCONFIG_MYSQLCONFIG_HOST": relational_db_data["endpoints"].split(":")[0],
+            "DBCONFIG_MYSQLCONFIG_PORT": relational_db_data["endpoints"].split(":")[1],
             "OBJECTSTORECONFIG_ACCESSKEY": objectstorage_data["access-key"],
             "OBJECTSTORECONFIG_SECRETACCESSKEY": objectstorage_data["secret-key"],
             "DEFAULTPIPELINERUNNERSERVICEACCOUNT": "default-editor",
@@ -743,8 +648,6 @@ class TestCharm:
 
     def _get_relation_db_only_side_effect_func(self, relation):
         """Returns relational-db relation with some data."""
-        if relation == "mysql":
-            return None
         if relation == "relational-db":
             return {"some-data": True}
 
@@ -898,59 +801,11 @@ class TestCharm:
         harness._emit_relation_broken(rel_name, rel_id, "kfp-api")
 
         assert harness.model.unit.status == BlockedStatus(
-            "Please add required database relation: eg. relational-db"
+            "Please add required `relational-db` database relation."
         )
 
         harness.charm.on.remove.emit()
         assert harness.model.unit.status == MaintenanceStatus("K8S resources removed")
-
-    def test_mysql_and_relational_db_both_present(
-        self,
-        mocked_resource_handler,
-        mocked_kubernetes_service_patcher,
-        harness: Harness,
-        mocked_lightkube_client,
-    ):
-        """Test that charm blocks when both mysql and relational-db relations are added."""
-        harness.set_leader(True)
-        harness.begin()
-
-        # Add mysql relation first
-        mysql_data = {
-            "database": "database",
-            "host": "host",
-            "root_password": "root_password",
-            "port": "port",
-        }
-        mysql_rel_id = harness.add_relation("mysql", "mysql-provider")
-        harness.add_relation_unit(mysql_rel_id, "mysql-provider/0")
-        harness.update_relation_data(mysql_rel_id, "mysql-provider/0", mysql_data)
-
-        # Mock the database library
-        database = MagicMock()
-        fetch_relation_data = MagicMock()
-        fetch_relation_data.return_value = {
-            "relational-db-data": {
-                "endpoints": "host:1234",
-                "username": "username",
-                "password": "password",
-            }
-        }
-        database.fetch_relation_data = fetch_relation_data
-        harness.charm.database = database
-
-        # Add relational-db relation - this should cause the charm status to be blocked
-        # due to the event handler detecting conflicting relations
-        relational_db_rel_id = harness.add_relation("relational-db", "relational-db-provider")
-        harness.add_relation_unit(relational_db_rel_id, "relational-db-provider/0")
-
-        # Verify charm is blocked due to conflicting database relations
-        # The blocking happens at the event handler level
-        assert isinstance(harness.charm.model.unit.status, BlockedStatus)
-        assert (
-            "remove deprecated mysql relation to unblock"
-            in harness.charm.model.unit.status.message.lower()
-        )
 
     def test_no_database_relation(
         self,
@@ -968,22 +823,22 @@ class TestCharm:
         with pytest.raises(ErrorWithStatus) as err:
             harness.charm._get_db_data()
         assert err.value.status_type(BlockedStatus)
-        assert "required database relation" in str(err).lower()
+        assert "please add required `relational-db` database" in str(err).lower()
 
     def setup_required_relations(self, harness: Harness):
         kfpapi_relation_name = "kfp-api"
         kfpapi_grpc_relation_name = "kfp-api-grpc"
 
-        # mysql relation
-        mysql_data = {
-            "database": "database",
-            "host": "host",
-            "root_password": "root_password",
-            "port": "port",
+        # relational-db relation
+        relational_db_data = {
+            "database": "mlpipeline",
+            "username": "root",
+            "password": "root_password",
+            "endpoints": "host:1234",
         }
-        mysql_rel_id = harness.add_relation("mysql", "mysql-provider")
-        harness.add_relation_unit(mysql_rel_id, "mysql-provider/0")
-        harness.update_relation_data(mysql_rel_id, "mysql-provider/0", mysql_data)
+        relational_db_rel_id = harness.add_relation("relational-db", "db-provider")
+        harness.add_relation_unit(relational_db_rel_id, "db-provider/0")
+        harness.update_relation_data(relational_db_rel_id, "db-provider", relational_db_data)
 
         # object storage relation
         objectstorage_data = {
@@ -1034,7 +889,13 @@ class TestCharm:
             kfpapi_grpc_rel_id, "kfp-api-grpc-subscriber", kfpapi_grpc_data
         )
 
-        return mysql_data, objectstorage_data, kfp_viz_data, kfpapi_rel_id, kfpapi_grpc_rel_id
+        return (
+            relational_db_data,
+            objectstorage_data,
+            kfp_viz_data,
+            kfpapi_rel_id,
+            kfpapi_grpc_rel_id,
+        )
 
     @pytest.mark.parametrize(
         "add_mesh_relation",


### PR DESCRIPTION
## Summary
This PR removes the long-deprecated `mysql` endpoint, which shouldn't be part of any supported Charmed Kubeflow deployment. This includes:
- Removal in `metadata.yaml`
- Removing the logic to get data from either this relation or `relational-db`, since only the latter is used now
- Un-observing the events in `src/charm.py`
- Removing all relevant unit tests

## Notes
- We actually still used the `mysql` relation in unit tests. I updated the tests to reflect the removal.

Closes #320