### PR TITLE
fix: Always have a non-empty region in the `kfp-launcher` ConfigMap

### DIFF
--- a/charms/kfp-profile-controller/src/components/object_storage_validator.py
+++ b/charms/kfp-profile-controller/src/components/object_storage_validator.py
@@ -14,6 +14,11 @@ from ops import ActiveStatus, BlockedStatus, CharmBase, StatusBase
 
 logger = logging.getLogger(__name__)
 
+# The AWS S3 SDK used by the kfp-launcher requires a non-empty region, even when talking to a
+# local storage that has no region concept. Use the same default as used in
+# `files/upstream/sync.py`
+DEFAULT_REGION = "us-east-1"
+
 
 class ObjectStorageValidatorComponent(Component):
     """Component that validates and normalizes data from the active object-storage relation.
@@ -125,7 +130,7 @@ class ObjectStorageValidatorComponent(Component):
                 "namespace": "",
                 "port": str(port),
                 "secure": secure,
-                "region": data.get("region", ""),
+                "region": data.get("region") or DEFAULT_REGION,
                 # The s3 interface has no namespace concept, so the endpoint is just host:port.
                 "endpoint": f"{host}:{port}",
             }
@@ -163,7 +168,7 @@ class ObjectStorageValidatorComponent(Component):
                 "namespace": data["namespace"],
                 "port": str(data["port"]),
                 "secure": data["secure"],
-                "region": "",
+                "region": DEFAULT_REGION,
                 # The object-storage interface uses a `host.namespace:port` endpoint.
                 "endpoint": f"{data['service']}.{data['namespace']}:{data['port']}",
             }

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -70,9 +70,10 @@ def generate_expected_environment(model_name: str, kfp_api_sa: str = "kfp-api") 
             f"{MOCK_OBJECT_STORAGE_DATA['port']}"
         ),
         "MINIO_SECRET_KEY": MOCK_OBJECT_STORAGE_DATA["secret-key"],
-        # object-storage (MinIO) data has secure=True and no region concept
+        # object-storage data has secure=True and no region concept, so the validator
+        # falls back to the default region set in the charm
         "MINIO_SSL": "true",
-        "MINIO_REGION": "",
+        "MINIO_REGION": "us-east-1",
         # Using custom image and tag from the JSON file
         "FRONTEND_IMAGE": custom_images["frontend"].split(":")[0],
         "FRONTEND_TAG": custom_images["frontend"].split(":")[1],
@@ -535,7 +536,8 @@ def test_pebble_services_running_with_s3(
             "MINIO_PORT": "443",
             "MINIO_ENDPOINT": "s3.example.com:443",
             "MINIO_SSL": "true",
-            "MINIO_REGION": "",
+            # Default region in the charm
+            "MINIO_REGION": "us-east-1",
         }
     )
     harness.begin()
@@ -977,6 +979,8 @@ def test_configmap_manifest_sent_when_configmaps_related(
     assert manifest["metadata"]["name"] == "kfp-launcher"
     assert "namespace" not in manifest["metadata"]
     assert "providers" in manifest["data"]
+    # Even if the region is non-required, expect the default one
+    assert "region: us-east-1" in manifest["data"]["providers"]
     assert manifest["data"]["defaultPipelineRoot"] == KFP_DEFAULT_PIPELINE_ROOT
 
 


### PR DESCRIPTION
## Summary
This PR updates the region in `kfp-launcher` to always be non-empty, otherwise the error in #979 is produced. This includes
- Update the region passed in both the workload container *and* the `ObjectStorageValidatorComponent` that is used by the `ResourceDispatcherManifestsComponent` component for `config-maps`.
- Update unit tests with the new defaults.

Closes #979